### PR TITLE
model the digests file and allow updating and saving changes

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -1,10 +1,10 @@
 require 'pathname'
 require 'singleton'
 require 'ns-options'
-require 'multi_json'
 
 require 'dassets/version'
 require 'dassets/root_path'
+require 'dassets/digests_file'
 
 module Dassets
 
@@ -30,23 +30,14 @@ module Dassets
     include Singleton
 
     def init(file_path)
-      @hash = MultiJson.decode(File.read(file_path))
+      @digests_file = DigestsFile.new(file_path)
     end
 
-    def reset
-      @hash = {}
-    end
+    def digests_file; @digests_file || {}; end
+    def reset; @digests_file = nil; end
 
-    # all objs define #hash so need to override it b/c method missing below won't work
-    def self.hash; self.instance.hash; end
-    def hash; @hash || {}; end
-
-    def empty?; self.hash.empty?; end
-    def [](*args); self.hash.send('[]', *args); end
-
-    def reset
-      @hash = {}
-    end
+    def empty?; self.digests_file.empty?; end
+    def [](*args); self.digests_file.send('[]', *args); end
 
     # nice singleton api
 

--- a/lib/dassets/digests_file.rb
+++ b/lib/dassets/digests_file.rb
@@ -1,0 +1,31 @@
+require 'multi_json'
+
+module Dassets; end
+class Dassets::DigestsFile
+
+  attr_reader :path
+
+  def initialize(file_path)
+    @path = file_path
+    @hash = MultiJson.decode(File.read(file_path))
+  end
+
+  def [](*args);  @hash.send('[]', *args);  end
+  def []=(*args); @hash.send('[]=', *args); end
+  def index_of(*args); @hash.send('index_of', *args); end
+
+  def keys;   @hash.keys;   end
+  def values; @hash.values; end
+  def empty?; @hash.empty?; end
+
+  def to_hash
+    Hash.new.tap do |to_hash|
+      @hash.each{ |k, v| to_hash[k] = v }
+    end
+  end
+
+  def save!
+    File.open(@path, 'w'){ |f| f.write(MultiJson.encode(@hash, :pretty => true)) }
+  end
+
+end

--- a/test/support/digests.json
+++ b/test/support/digests.json
@@ -1,0 +1,5 @@
+{
+  "/path/to/file1": "abc123",
+  "/path/to/file2": "123abc",
+  "/path/to/file3": "a1b2c3"
+}

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -15,7 +15,9 @@ module Dassets
     end
 
     should "read/parse the digests on init" do
+      Dassets.digests.reset
       assert_empty Dassets.digests
+
       subject.init
       assert_not_empty Dassets.digests
     end

--- a/test/unit/digests_file_tests.rb
+++ b/test/unit/digests_file_tests.rb
@@ -1,0 +1,68 @@
+require 'assert'
+require 'fileutils'
+require 'dassets/digests_file'
+
+class Dassets::DigestsFile
+
+  class BaseTests < Assert::Context
+    desc "Dassets::DigestsFile"
+    setup do
+      @file_path = File.join(ROOT_PATH, 'test/support/digests.json')
+      @digests = Dassets::DigestsFile.new(@file_path)
+    end
+    subject{ @digests }
+
+    should have_imeths :path, :to_hash, :save!
+    should have_imeths :[], :[]=, :index_of, :keys, :values, :empty?
+
+    should "know its path" do
+      assert_equal @file_path, subject.path
+    end
+
+    should "know whether it is empty or not" do
+      assert_not_empty subject
+    end
+
+    should "read values with the index operator" do
+      assert_equal 'abc123', subject['/path/to/file1']
+    end
+
+    should "write values with the index operator" do
+      subject['/path/to/test'] = 'testytest'
+      assert_equal 'testytest', subject['/path/to/test']
+    end
+
+    should "know its hash representation" do
+      exp_hash = {
+        "/path/to/file1" => "abc123",
+        "/path/to/file2" => "123abc",
+        "/path/to/file3" => "a1b2c3"
+      }
+      subject_to_hash = subject.to_hash
+      subject_internal_hash = subject.instance_variable_get("@hash")
+
+      assert_equal exp_hash, subject_to_hash
+      assert_not_equal subject_internal_hash.object_id, subject_to_hash.object_id
+    end
+
+  end
+
+  class SaveTests < BaseTests
+    desc "on save"
+    setup do
+      FileUtils.mv(@file_path, "#{@file_path}.bak")
+    end
+    teardown do
+      FileUtils.mv("#{@file_path}.bak", @file_path)
+    end
+
+    should "write out the digests to the path" do
+      assert_not_file_exists subject.path
+      subject.save!
+
+      assert_file_exists subject.path
+    end
+
+  end
+
+end

--- a/test/unit/digests_tests.rb
+++ b/test/unit/digests_tests.rb
@@ -1,5 +1,6 @@
 require 'assert'
 require 'dassets'
+require 'dassets/digests_file'
 
 class Dassets::Digests
 
@@ -13,18 +14,18 @@ class Dassets::Digests
       subject.reset
     end
 
-    should have_imeths :init, :reset, :hash, :empty?, :[]
+    should have_imeths :init, :digests_file, :reset, :empty?, :[]
 
     should "be a singleton" do
       assert_includes Singleton, subject.included_modules
     end
 
-    should "know its full hash" do
-      digests_hash = subject.hash
+    should "know its digests file" do
+      digests_file = subject.digests_file
 
-      assert_kind_of Hash, digests_hash
-      assert_not_empty digests_hash
-      assert_equal digests_hash[digests_hash.keys.first], subject[digests_hash.keys.first]
+      assert_kind_of Dassets::DigestsFile, digests_file
+      assert_not_empty digests_file
+      assert_equal digests_file[digests_file.keys.first], subject[digests_file.keys.first]
     end
 
   end


### PR DESCRIPTION
This adds formal modeling of the digests file.  It encapsulates
reading and updating the file and provides a nice hash-like api
for reading and writing values.

This will be used by the upcoming `digest` subcommand when it
digests asset files and updates the digest file.

@jcredding ready for review.
