### PR TITLE
model the asset file

### DIFF
--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -1,0 +1,16 @@
+require 'digest/md5'
+
+module Dassets; end
+class Dassets::AssetFile
+
+  attr_reader :path
+
+  def initialize(file_path)
+    @path = file_path
+  end
+
+  def md5
+    Digest::MD5.file(@path).hexdigest
+  end
+
+end

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -1,0 +1,26 @@
+require 'assert'
+require 'dassets/asset_file'
+
+class Dassets::AssetFile
+
+  class BaseTests < Assert::Context
+    desc "Dassets::AssetFile"
+    setup do
+      @file_path = File.join(Dassets.config.files_path, 'file1.txt')
+      @asset_file = Dassets::AssetFile.new(@file_path)
+    end
+    subject{ @asset_file }
+
+    should have_imeths :path, :md5
+
+    should "know its path" do
+      assert_equal @file_path, subject.path
+    end
+
+    should "compute its md5 checksum" do
+      assert_equal 'daa05c683a4913b268653f7a7e36a5b4', subject.md5
+    end
+
+  end
+
+end


### PR DESCRIPTION
This abstracts how the asset md5 checksum is calculated and provides
in a convenient API.

This will be used the the digest subcommand when building the
digests file.

@jcredding ready for review.  pretty straightforward.
