### PR TITLE
asset file rework

### DIFF
--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -3,17 +3,16 @@ require 'digest/md5'
 module Dassets; end
 class Dassets::AssetFile
 
-  def initialize(absolute_path, relative_to_path)
-    @absolute_path = absolute_path
-    @relative_to_path = relative_to_path
+  def self.from_abs_path(abs_path)
+    path = abs_path.sub("#{Dassets.config.files_path}/", '')
+    md5  = Digest::MD5.file(abs_path).hexdigest
+    self.new(path, md5)
   end
 
-  def md5
-    Digest::MD5.file(@absolute_path).hexdigest
-  end
+  attr_reader :path, :md5
 
-  def path
-    @absolute_path.sub(@relative_to_path, '')
+  def initialize(path, md5)
+    @path, @md5 = path, md5
   end
 
 end

--- a/lib/dassets/runner/digest_command.rb
+++ b/lib/dassets/runner/digest_command.rb
@@ -43,7 +43,7 @@ class Dassets::Runner::DigestCommand
     fuzzy_paths(paths).
       select{ |p| is_asset_file?(p) }.
       sort.
-      map{ |p| Dassets::AssetFile.new(p, file_root_path) }
+      map{ |p| Dassets::AssetFile.from_abs_path(p) }
   end
 
   def fuzzy_paths(paths)
@@ -54,11 +54,7 @@ class Dassets::Runner::DigestCommand
   end
 
   def is_asset_file?(path)
-    File.file?(path) && path.include?(file_root_path)
-  end
-
-  def file_root_path
-    "#{Dassets.config.files_path}/"
+    File.file?(path) && path.include?("#{Dassets.config.files_path}/")
   end
 
 end

--- a/test/support/app/assets/.digests
+++ b/test/support/app/assets/.digests
@@ -1,6 +1,6 @@
 {
-  "grumpy_cat.jpg": "b0d1f399a916f7a25c4c0f693c619013",
   "file1.txt": "daa05c683a4913b268653f7a7e36a5b4",
   "nested/file3.txt": "d41d8cd98f00b204e9800998ecf8427e",
-  "file2.txt": "9bbe1047cffbb590f59e0e5aeff46ae4"
+  "file2.txt": "9bbe1047cffbb590f59e0e5aeff46ae4",
+  "grumpy_cat.jpg": "b0d1f399a916f7a25c4c0f693c619013"
 }

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -6,19 +6,25 @@ class Dassets::AssetFile
   class BaseTests < Assert::Context
     desc "Dassets::AssetFile"
     setup do
-      @file_path = File.join(Dassets.config.files_path, 'file1.txt')
-      @asset_file = Dassets::AssetFile.new(@file_path, "#{Dassets.config.files_path}/")
+      @asset_file = Dassets::AssetFile.new('file1.txt', 'abc123')
     end
     subject{ @asset_file }
 
-    should have_imeths :path, :md5
+    should have_cmeths :from_abs_path
+    should have_readers :path, :md5
 
-    should "track it's path relative to its given relative path" do
+    should "know its given path and md5" do
       assert_equal 'file1.txt', subject.path
+      assert_equal 'abc123', subject.md5
     end
 
-    should "compute its md5 checksum" do
-      assert_equal 'daa05c683a4913b268653f7a7e36a5b4', subject.md5
+    should "be created from absolute file paths and have md5 computed" do
+      abs_file_path = File.join(Dassets.config.files_path, 'file1.txt')
+      exp_md5 = 'daa05c683a4913b268653f7a7e36a5b4'
+      file = Dassets::AssetFile.from_abs_path(abs_file_path)
+
+      assert_equal 'file1.txt', file.path
+      assert_equal exp_md5, file.md5
     end
 
   end


### PR DESCRIPTION
This reworks the asset file to be a little more generic and
expandable.  Now it just takes a path and md5 value and provides
readers for them since they "travel together".

In addition, it has a class method for creating given an absolute
file path.  This interface reads the file and computes the md5
fingerprint.  It also stores the path relative the the
`config.files_path` setting.  The digest command has been updated
to use this interface.

@jcredding like we talked about, here is the `from_abs_path` interface.  ready for review.
