### PR TITLE
replace JSON digests file encoding with custom CSV-like encoding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,3 @@ gemspec
 
 gem 'rake'
 gem 'pry'
-gem 'yajl-ruby'

--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency("assert", ["~> 2.0"])
 
   gem.add_dependency('ns-options',    ["~> 1.1"])
-  gem.add_dependency('multi_json',  ['~> 1.3'])
 
 end

--- a/test/support/app/assets/.digests
+++ b/test/support/app/assets/.digests
@@ -1,6 +1,4 @@
-{
-  "nested/file3.txt": "d41d8cd98f00b204e9800998ecf8427e",
-  "grumpy_cat.jpg": "b0d1f399a916f7a25c4c0f693c619013",
-  "file1.txt": "daa05c683a4913b268653f7a7e36a5b4",
-  "file2.txt": "9bbe1047cffbb590f59e0e5aeff46ae4"
-}
+file1.txt,daa05c683a4913b268653f7a7e36a5b4
+file2.txt,9bbe1047cffbb590f59e0e5aeff46ae4
+grumpy_cat.jpg,b0d1f399a916f7a25c4c0f693c619013
+nested/file3.txt,d41d8cd98f00b204e9800998ecf8427e

--- a/test/support/digests.json
+++ b/test/support/digests.json
@@ -1,5 +1,0 @@
-{
-  "/path/to/file1": "abc123",
-  "/path/to/file2": "123abc",
-  "/path/to/file3": "a1b2c3"
-}

--- a/test/support/example.digests
+++ b/test/support/example.digests
@@ -1,0 +1,3 @@
+/path/to/file1,abc123
+/path/to/file2,123abc
+/path/to/file3,a1b2c3

--- a/test/unit/digests_file_tests.rb
+++ b/test/unit/digests_file_tests.rb
@@ -8,7 +8,7 @@ class Dassets::DigestsFile
   class BaseTests < Assert::Context
     desc "Dassets::DigestsFile"
     setup do
-      @file_path = File.join(ROOT_PATH, 'test/support/digests.json')
+      @file_path = File.join(ROOT_PATH, 'test/support/example.digests')
       @digests = Dassets::DigestsFile.new(@file_path)
     end
     subject{ @digests }


### PR DESCRIPTION
This change moves to custom encoding and decoding of the digests
hash.  This is done b/c we cannot control the order of the keys
that are encoded with JSON.  This means that each time you write
the digests, the digest file changes due to order changes.

This won't work well with the pattern of checking in digest files
to source control.

Using this custom CSV-like encoding, we can sort the enties to
give a more deterministic digest file output.

@jcredding ready for review
