### PR TITLE
Dassets index operator for looking up asset files by path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Use the CLI to build your digests file.  Protip: use guard to auto rebuild diges
 ### Link To
 
 ```rb
-Dassets['css/site.css'].href       # => "css/site-123abc.css"
-Dassets['img/logos/main.jpg'].href # => "img/logos/main-a1b2c3.jpg"
+Dassets['css/site.css'].href       # => "/css/site-123abc.css"
+Dassets['img/logos/main.jpg'].href # => "/img/logos/main-a1b2c3.jpg"
 ```
 
 ### Serve

--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -19,6 +19,9 @@ module Dassets
   end
 
   def self.digests; @digests_file || NullDigestsFile.new; end
+  def self.[](asset_path)
+    self.digests.asset_file(asset_path)
+  end
 
   class Config
     include NsOptions::Proxy

--- a/lib/dassets/digests_file.rb
+++ b/lib/dassets/digests_file.rb
@@ -22,6 +22,10 @@ module Dassets
       @hash.map{ |path, md5| Dassets::AssetFile.new(path, md5) }
     end
 
+    def asset_file(path)
+      Dassets::AssetFile.new(path, @hash[path] || '')
+    end
+
     def to_hash
       Hash.new.tap do |to_hash|
         @hash.each{ |k, v| to_hash[k] = v }

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -8,7 +8,7 @@ module Dassets
     desc "Dassets"
     subject{ Dassets }
 
-    should have_imeths :config, :configure, :init, :digests
+    should have_imeths :config, :configure, :init, :digests, :[]
 
     should "return its `Config` class with the `config` method" do
       assert_same Config, subject.config
@@ -20,6 +20,28 @@ module Dassets
 
       subject.init
       assert_not_empty subject.digests
+    end
+
+    should "return asset files given a their path using the index operator" do
+      subject.init
+      file = subject['nested/file3.txt']
+
+      assert_kind_of Dassets::AssetFile, file
+      assert_equal 'nested/file3.txt', file.path
+      assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.md5
+
+      subject.reset
+    end
+
+    should "return an asset file with no fingerprint if path not in digests" do
+      file = subject['path/not/found.txt']
+      assert_equal '', file.md5
+
+      subject.init
+      file = subject['path/not/found.txt']
+      assert_equal '', file.md5
+
+      subject.reset
     end
 
   end

--- a/test/unit/digests_file_tests.rb
+++ b/test/unit/digests_file_tests.rb
@@ -14,7 +14,7 @@ class Dassets::DigestsFile
     subject{ @digests }
 
     should have_reader :path
-    should have_imeths :asset_files, :to_hash, :save!
+    should have_imeths :asset_files, :asset_file, :to_hash, :save!
     should have_imeths :[], :[]=, :delete, :each, :keys, :values, :empty?
 
     should "know its path" do
@@ -24,6 +24,14 @@ class Dassets::DigestsFile
     should "know its asset files" do
       assert_equal subject.keys.size, subject.asset_files.size
       assert_kind_of Dassets::AssetFile, subject.asset_files.first
+    end
+
+    should "get a specific asset file from its data" do
+      file = subject.asset_file('/path/to/file1')
+
+      assert_kind_of Dassets::AssetFile, file
+      assert_equal '/path/to/file1', file.path
+      assert_equal subject['/path/to/file1'], file.md5
     end
 
     should "know whether it is empty or not" do


### PR DESCRIPTION
Given a path, the index operator will return an asset file instance.
Use this to access and work with asset file data.  An example
application would be to generate href paths to hosted asset files
in your web views.

@jcredding ready for review.  This doesn't include adding any cool data readers on the asset file model - yet.
