### PR TITLE
adding file related attrs to asset file model

### DIFF
--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -4,24 +4,23 @@ module Dassets; end
 class Dassets::AssetFile
 
   def self.from_abs_path(abs_path)
-    path = abs_path.sub("#{Dassets.config.files_path}/", '')
+    rel_path = abs_path.sub("#{Dassets.config.files_path}/", '')
     md5  = Digest::MD5.file(abs_path).hexdigest
-    self.new(path, md5)
+    self.new(rel_path, md5)
   end
 
-  attr_reader :path, :md5
+  attr_reader :path, :md5, :dirname, :extname, :basename
+  attr_reader :cache_path, :href
 
-  def initialize(path, md5)
-    @path, @md5 = path, md5
-  end
+  def initialize(rel_path, md5)
+    @path, @md5 = rel_path, md5
+    @dirname  = File.dirname(@path)
+    @extname  = File.extname(@path)
+    @basename = File.basename(@path, @extname)
 
-  def cache_path
-    fingerprint = @md5
-    dirname     = File.dirname(@path)
-    extname     = File.extname(@path)
-    basename    = File.basename(@path, extname)
-
-    File.join(dirname, "#{basename}-#{fingerprint}#{extname}")
+    file_name = "#{@basename}-#{@md5}#{@extname}"
+    @cache_path = File.join(@dirname, file_name).sub(/^\.\//, '').sub(/^\//, '')
+    @href = "/#{@cache_path}"
   end
 
 end

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -11,24 +11,32 @@ class Dassets::AssetFile
     subject{ @asset_file }
 
     should have_cmeths :from_abs_path
-    should have_readers :path, :md5
-    should have_imeth :cache_path
+    should have_readers :path, :md5, :dirname, :extname, :basename
+    should have_readers :cache_path, :href
 
     should "know its given path and md5" do
       assert_equal 'file1.txt', subject.path
       assert_equal 'abc123', subject.md5
     end
 
+    should "know its dirname, extname, and basename" do
+      assert_equal '.',     subject.dirname
+      assert_equal '.txt',  subject.extname
+      assert_equal 'file1', subject.basename
+    end
+
     should "build it's cache_path from the path and the md5" do
-      path = subject.path
-      fingerprint = subject.md5
+      assert_equal "file1-abc123.txt", subject.cache_path
 
-      dirname  = File.dirname(path)
-      extname  = File.extname(path)
-      basename = File.basename(path, extname)
-      exp_path = File.join(dirname, "#{basename}-#{fingerprint}#{extname}")
+      nested = Dassets::AssetFile.new('nested/file1.txt', 'abc123')
+      assert_equal "nested/file1-abc123.txt", nested.cache_path
+    end
 
-      assert_equal exp_path, subject.cache_path
+    should "build it's href from the cache path" do
+      assert_equal "/file1-abc123.txt", subject.href
+
+      nested = Dassets::AssetFile.new('nested/file1.txt', 'abc123')
+      assert_equal "/nested/file1-abc123.txt", nested.href
     end
 
     should "be created from absolute file paths and have md5 computed" do


### PR DESCRIPTION
This adds some file attrs to model and uses those attrs to compute
the cache path.  This allows the cache path to be stored as an
instance var and accessed as a reader.

In addition, this adds an `href` reader for accessing the href url
for the asset file.

@jcredding ready for review.
