### PR TITLE
rack middleware for serving asset files

### DIFF
--- a/bin/dassets
+++ b/bin/dassets
@@ -3,5 +3,6 @@
 # Copyright (c) 2013-Present Kelly Redding and Collin Redding
 #
 
+ENV['DASSETS_ROOT_PATH'] ||= Dir.pwd
 require 'dassets/cli'
 Dassets::CLI.run *ARGV

--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.0"])
 
-  gem.add_dependency('ns-options',    ["~> 1.1"])
+  gem.add_dependency('ns-options', ["~> 1.1"])
+  gem.add_dependency("rack",       ["~> 1.0"])
 
 end

--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -1,4 +1,6 @@
 require 'digest/md5'
+require 'rack/utils'
+require 'rack/mime'
 
 module Dassets; end
 class Dassets::AssetFile
@@ -10,7 +12,7 @@ class Dassets::AssetFile
   end
 
   attr_reader :path, :md5, :dirname, :extname, :basename
-  attr_reader :cache_path, :href
+  attr_reader :files_path, :cache_path, :href
 
   def initialize(rel_path, md5)
     @path, @md5 = rel_path, md5
@@ -19,8 +21,45 @@ class Dassets::AssetFile
     @basename = File.basename(@path, @extname)
 
     file_name = "#{@basename}-#{@md5}#{@extname}"
+    @files_path = File.join(Dassets.config.files_path, @path)
     @cache_path = File.join(@dirname, file_name).sub(/^\.\//, '').sub(/^\//, '')
     @href = "/#{@cache_path}"
+  end
+
+  def content
+    @content ||= if File.exists?(@files_path) && File.file?(@files_path)
+      File.read(@files_path)
+    end
+  end
+
+  def mtime
+    @mtime ||= if File.exists?(@files_path) && File.file?(@files_path)
+      File.mtime(@files_path).httpdate
+    end
+  end
+
+  # We check via File::size? whether this file provides size info via stat,
+  # otherwise we have to figure it out by reading the whole file into memory.
+  def size
+    @size ||= if File.exists?(@files_path) && File.file?(@files_path)
+      File.size?(@files_path) || Rack::Utils.bytesize(self.content)
+    end
+  end
+
+  def mime_type
+    @mime_type ||= if File.exists?(@files_path) && File.file?(@files_path)
+      Rack::Mime.mime_type(@extname)
+    end
+  end
+
+  def exists?
+    File.exists?(@files_path) && File.file?(@files_path)
+  end
+
+  def ==(other_asset_file)
+    other_asset_file.kind_of?(Dassets::AssetFile) &&
+    self.path == other_asset_file.path &&
+    self.md5 == other_asset_file.md5
   end
 
 end

--- a/lib/dassets/runner.rb
+++ b/lib/dassets/runner.rb
@@ -13,7 +13,7 @@ class Dassets::Runner
     @opts = opts
     @cmd_name = args.shift || ""
     @cmd_args = args
-    @root_path = @opts.delete('root_path') || Dir.pwd
+    @root_path = @opts.delete('root_path') || ENV['DASSETS_ROOT_PATH']
   end
 
   def run

--- a/lib/dassets/server.rb
+++ b/lib/dassets/server.rb
@@ -1,0 +1,37 @@
+require 'dassets/server/request'
+require 'dassets/server/response'
+
+# Rack middleware for serving Dassets asset files
+
+module Dassets
+  class Server
+
+    def initialize(app)
+      @app = app
+    end
+
+    # The Rack call interface. The receiver acts as a prototype and runs
+    # each request in a clone object unless the +rack.run_once+ variable is
+    # set in the environment. Ripped from:
+    # http://github.com/rtomayko/rack-cache/blob/master/lib/rack/cache/context.rb
+    def call(env)
+      if env['rack.run_once']
+        call! env
+      else
+        clone.call! env
+      end
+    end
+
+    # The real Rack call interface.
+    # if an asset file is being requested, this is an endpoint - otherwise, call
+    # on up to the app as normal
+    def call!(env)
+      if (request = Request.new(env)).for_asset_file?
+        Response.new(env, request.asset_file).to_rack
+      else
+        @app.call(env)
+      end
+    end
+
+  end
+end

--- a/lib/dassets/server/request.rb
+++ b/lib/dassets/server/request.rb
@@ -1,0 +1,48 @@
+require 'rack/request'
+
+class Dassets::Server
+
+  class Request < Rack::Request
+
+    # The HTTP request method. This is the standard implementation of this
+    # method but is respecified here due to libraries that attempt to modify
+    # the behavior to respect POST tunnel method specifiers. We always want
+    # the real request method.
+    def request_method; @env['REQUEST_METHOD']; end
+    def path_info;      @env['PATH_INFO'];      end
+
+    # Determine if the request is for an asset file
+    # This will be called on every request so speed is an issue
+    # - first check if the request is a GET (fast)
+    # - then check if for a digest resource (kinda fast)
+    # - then check if on a path in the digests (slower)
+    def for_asset_file?
+      !!(get? && for_digest_file? && Dassets.digests[asset_path])
+    end
+
+    def asset_path
+      @asset_path ||= path_digest_match.captures.select{ |m| !m.empty? }.join
+    end
+
+    def asset_file
+      @asset_file ||= Dassets[asset_path]
+    end
+
+    private
+
+    def for_digest_file?
+      !path_digest_match.nil?
+    end
+
+    def path_digest_match
+      @path_digest_match ||= begin
+        path_info.match(/\/(.+)-[a-f0-9]{32}(\..+|)$/i) || NullDigestMatch.new
+      end
+    end
+
+    class NullDigestMatch
+      def captures; []; end
+    end
+
+  end
+end

--- a/lib/dassets/server/response.rb
+++ b/lib/dassets/server/response.rb
@@ -1,0 +1,36 @@
+require 'rack/response'
+require 'rack/utils'
+require 'rack/mime'
+
+class Dassets::Server
+
+  class Response
+    attr_reader :asset_file, :status, :headers, :body
+
+    def initialize(env, asset_file)
+      @asset_file = asset_file
+
+      mtime = @asset_file.mtime.to_s
+      @status, @headers, @body = if env['HTTP_IF_MODIFIED_SINCE'] == mtime
+        [ 304, Rack::Utils::HeaderHash.new, [] ]
+      elsif !@asset_file.exists?
+        [ 404, Rack::Utils::HeaderHash.new, [] ]
+      else
+        [ 200,
+          Rack::Utils::HeaderHash.new.tap do |h|
+            h["Content-Type"]   = @asset_file.mime_type.to_s
+            h["Content-Length"] = @asset_file.size.to_s
+            h["Last-Modified"]  = mtime
+          end,
+          env["REQUEST_METHOD"] == "HEAD" ? [] : [ @asset_file.content ]
+        ]
+      end
+    end
+
+    def to_rack
+      [@status, @headers.to_hash, @body]
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,4 +8,6 @@ $LOAD_PATH.unshift(ROOT_PATH)
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
+ENV['DASSETS_ROOT_PATH'] ||= Dir.pwd
+
 require 'test/support/config/dassets.rb'

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -12,7 +12,8 @@ class Dassets::AssetFile
 
     should have_cmeths :from_abs_path
     should have_readers :path, :md5, :dirname, :extname, :basename
-    should have_readers :cache_path, :href
+    should have_readers :files_path, :cache_path, :href
+    should have_imeth :content, :mtime, :size, :mime_type, :exists?, :==
 
     should "know its given path and md5" do
       assert_equal 'file1.txt', subject.path
@@ -23,6 +24,13 @@ class Dassets::AssetFile
       assert_equal '.',     subject.dirname
       assert_equal '.txt',  subject.extname
       assert_equal 'file1', subject.basename
+    end
+
+    should "build it's files_path from the path" do
+      assert_equal "#{Dassets.config.files_path}/file1.txt", subject.files_path
+
+      nested = Dassets::AssetFile.new('nested/file1.txt', 'abc123')
+      assert_equal "#{Dassets.config.files_path}/nested/file1.txt", nested.files_path
     end
 
     should "build it's cache_path from the path and the md5" do
@@ -46,6 +54,21 @@ class Dassets::AssetFile
 
       assert_equal 'file1.txt', file.path
       assert_equal exp_md5, file.md5
+    end
+
+    should "know it's content, mtime, size, mime_type, and if it exists" do
+      assert_equal "file1.txt\n", subject.content
+      assert_equal File.mtime(subject.files_path).httpdate, subject.mtime
+      assert_equal File.size?(subject.files_path), subject.size
+      assert_equal "text/plain", subject.mime_type
+      assert subject.exists?
+
+      null_file = Dassets::AssetFile.new('', '')
+      assert_nil null_file.content
+      assert_nil null_file.mtime
+      assert_nil null_file.size
+      assert_nil null_file.mime_type
+      assert_not null_file.exists?
     end
 
   end

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -1,0 +1,76 @@
+require 'assert'
+require 'dassets/server/request'
+
+class Dassets::Server::Request
+
+  class BaseTests < Assert::Context
+    desc "Dassets::Server::Request"
+    setup do
+      Dassets.init
+      @req = file_request('GET', '/file1-daa05c683a4913b268653f7a7e36a5b4.txt')
+    end
+    teardown do
+      Dassets.reset
+    end
+    subject{ @req }
+
+    should have_imeths :for_asset_file?, :asset_path, :asset_file
+
+    should "know its asset_path" do
+      assert_equal 'file1.txt', subject.asset_path
+    end
+
+    should "know its asset_file" do
+      assert_equal Dassets['file1.txt'], subject.asset_file
+    end
+
+    should "know if it is for an asset file" do
+      # find nested path with matching md5
+      req = file_request('GET', '/nested/file3-d41d8cd98f00b204e9800998ecf8427e.txt')
+      assert req.for_asset_file?
+
+      # find not nested path with matching md5
+      req = file_request('GET', '/file1-daa05c683a4913b268653f7a7e36a5b4.txt')
+      assert req.for_asset_file?
+
+      # find even if md5 is *not* matching - just need to have any md5
+      req = file_request('GET', '/file1-d41d8cd98f00b204e9800998ecf8427e.txt')
+      assert req.for_asset_file?
+
+      # no find on invalid md5
+      req = file_request('GET', '/file1-daa05c683a4913b268653f7a7e36a.txt')
+      assert_not req.for_asset_file?
+
+      # no find on missing md5
+      req = file_request('GET', '/file1.txt')
+      assert_not req.for_asset_file?
+
+      # no find on unknown file
+      req = file_request('GET', '/some-file.txt')
+      assert_not req.for_asset_file?
+
+      # no find on unknown file with an md5
+      req = file_request('GET', '/some-file-daa05c683a4913b268653f7a7e36a5b4.txt')
+      assert_not req.for_asset_file?
+    end
+
+    should "return an asset path and an empty asset file if request not for asset file" do
+      req = file_request('GET', '/some-file.txt')
+
+      assert_equal '', req.asset_path
+      assert_equal Dassets::AssetFile.new('', ''), req.asset_file
+    end
+
+    protected
+
+    def file_request(method, path_info)
+      require 'dassets/server/request'
+      Dassets::Server::Request.new({
+        'REQUEST_METHOD' => method,
+        'PATH_INFO'      => path_info
+      })
+    end
+
+  end
+
+end

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -1,0 +1,70 @@
+require 'assert'
+require 'rack/utils'
+require 'dassets/server/response'
+
+class Dassets::Server::Response
+
+  class BaseTests < Assert::Context
+    desc "Dassets::Server::Response"
+    setup do
+      @resp = file_response(Dassets::AssetFile.new('', ''))
+    end
+    subject{ @resp }
+
+    should have_readers :asset_file, :status, :headers, :body
+    should have_imeths :to_rack
+
+    should "handle not modified files" do
+      af = Dassets['file1.txt']
+      mtime = File.mtime(af.files_path).httpdate.to_s
+      resp = file_response(af, 'HTTP_IF_MODIFIED_SINCE' => mtime)
+
+      assert_equal 304, resp.status
+      assert_equal [], resp.body
+      assert_equal Rack::Utils::HeaderHash.new, resp.headers
+      assert_equal [ 304, {}, [] ], resp.to_rack
+    end
+
+    should "handle found files" do
+      af = Dassets['file1.txt']
+      resp = file_response(af)
+      exp_headers = {
+        'Content-Type'   => 'text/plain',
+        'Content-Length' => File.size?(af.files_path).to_s,
+        'Last-Modified'  => File.mtime(af.files_path).httpdate.to_s
+      }
+
+      assert_equal 200, resp.status
+      assert_equal [ af.content ], resp.body
+      assert_equal exp_headers, resp.headers
+      assert_equal [ 200, exp_headers, [ af.content ] ], resp.to_rack
+    end
+
+    should "have an empty body for found files with a HEAD request" do
+      af = Dassets['file1.txt']
+      resp = file_response(af, 'REQUEST_METHOD' => 'HEAD')
+
+      assert_equal 200, resp.status
+      assert_equal [], resp.body
+    end
+
+    should "handle not found files" do
+      af = Dassets['not-found-file.txt']
+      resp = file_response(af)
+
+      assert_equal 404, resp.status
+      assert_equal [], resp.body
+      assert_equal Rack::Utils::HeaderHash.new, resp.headers
+      assert_equal [ 404, {}, [] ], resp.to_rack
+    end
+
+    protected
+
+    def file_response(asset_file, env={})
+      require 'dassets/server/response'
+      Dassets::Server::Response.new(env, asset_file)
+    end
+
+  end
+
+end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -1,0 +1,17 @@
+require 'assert'
+require 'dassets/server'
+
+class Dassets::Server
+
+  class BaseTests < Assert::Context
+    desc "Dassets::Server"
+    setup do
+      @server = Dassets::Server.new('a rack app goes here')
+    end
+    subject{ @server }
+
+    should have_imeths :call, :call!
+
+  end
+
+end


### PR DESCRIPTION
This adds a middleware for serving asset file requests.  It analyzes
the request: if it is for an asset file, it builds an appropriate
response to serve the file - otherwise it calls up the middleware
chain.

This is intended to be used in development so that digested assets
don't _have_ to be copied to the public directory.

Ideally, this would not be used in non-development.  In that case,
the asset files should be copied to the public dir on deploy so that
the webserver can serve them directly.

@jcredding ready for review
