### PR TITLE
have an ENV var drive what file the CLI loads to configure Dassets

### DIFF
--- a/bin/dassets
+++ b/bin/dassets
@@ -3,6 +3,5 @@
 # Copyright (c) 2013-Present Kelly Redding and Collin Redding
 #
 
-ENV['DASSETS_ROOT_PATH'] ||= Dir.pwd
 require 'dassets/cli'
 Dassets::CLI.run *ARGV

--- a/lib/dassets/cli.rb
+++ b/lib/dassets/cli.rb
@@ -10,11 +10,7 @@ module Dassets
     end
 
     def initialize
-      @cli = CLIRB.new do
-        option 'root_path', 'root path Dassets should use (`Dir.pwd`)', {
-          :abbrev => 'p', :value => String
-        }
-      end
+      @cli = CLIRB.new
     end
 
     def run(*args)

--- a/lib/dassets/runner.rb
+++ b/lib/dassets/runner.rb
@@ -1,23 +1,24 @@
 require 'dassets'
 require 'dassets/runner/digest_command'
 
+ENV['DASSETS_CONFIG_FILE'] ||= 'config/assets'
+
 module Dassets; end
 class Dassets::Runner
   UnknownCmdError = Class.new(ArgumentError)
   CmdError = Class.new(RuntimeError)
   CmdFail = Class.new(RuntimeError)
 
-  attr_reader :cmd_name, :cmd_args, :opts, :root_path
+  attr_reader :cmd_name, :cmd_args, :opts
 
   def initialize(args, opts)
     @opts = opts
     @cmd_name = args.shift || ""
     @cmd_args = args
-    @root_path = @opts.delete('root_path') || ENV['DASSETS_ROOT_PATH']
   end
 
   def run
-    DassetsConfigFile.new(@root_path).require_if_exists
+    require ENV['DASSETS_CONFIG_FILE']
 
     case @cmd_name
     when 'digest'
@@ -28,17 +29,6 @@ class Dassets::Runner
       NullCommand.new.run
     else
       raise UnknownCmdError, "unknown command `#{@cmd_name}`"
-    end
-  end
-
-  class DassetsConfigFile
-    PATH = 'config/dassets.rb'
-    def initialize(root_path)
-      @path = File.join(root_path, PATH)
-    end
-
-    def require_if_exists
-      require @path.to_s if File.exists?(@path.to_s)
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,12 +2,10 @@
 # put any test helpers here
 
 # add the root dir to the load path
-ROOT_PATH = File.expand_path("../..", __FILE__)
-$LOAD_PATH.unshift(ROOT_PATH)
+$LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
-ENV['DASSETS_ROOT_PATH'] ||= Dir.pwd
-
-require 'test/support/config/dassets.rb'
+ENV['DASSETS_CONFIG_FILE'] = 'test/support/config/assets'
+require ENV['DASSETS_CONFIG_FILE']

--- a/test/support/config/assets.rb
+++ b/test/support/config/assets.rb
@@ -1,0 +1,7 @@
+require 'dassets'
+
+Dassets.configure do |c|
+  c.root_path File.expand_path("../..", __FILE__)
+
+end
+

--- a/test/support/config/dassets.rb
+++ b/test/support/config/dassets.rb
@@ -1,7 +1,0 @@
-require 'dassets'
-
-Dassets.configure do |c|
-  c.root_path File.join(ROOT_PATH, 'test', 'support')
-
-end
-

--- a/test/unit/digests_file_tests.rb
+++ b/test/unit/digests_file_tests.rb
@@ -8,7 +8,7 @@ class Dassets::DigestsFile
   class BaseTests < Assert::Context
     desc "Dassets::DigestsFile"
     setup do
-      @file_path = File.join(ROOT_PATH, 'test/support/example.digests')
+      @file_path = File.join(Dassets.config.root_path, 'example.digests')
       @digests = Dassets::DigestsFile.new(@file_path)
     end
     subject{ @digests }

--- a/test/unit/runner/cache_command_tests.rb
+++ b/test/unit/runner/cache_command_tests.rb
@@ -7,7 +7,7 @@ class Dassets::Runner::CacheCommand
   class BaseTests < Assert::Context
     desc "Dassets::Runner::CacheCommand"
     setup do
-      @cache_root_path = File.join(ROOT_PATH, 'test/support/public')
+      @cache_root_path = File.join(Dassets.config.root_path, 'public')
       FileUtils.mkdir_p @cache_root_path
       @cmd = Dassets::Runner::CacheCommand.new(@cache_root_path)
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -11,37 +11,12 @@ class Dassets::Runner
     end
     subject{ @runner }
 
-    should have_readers :cmd_name, :cmd_args, :opts, :root_path
+    should have_readers :cmd_name, :cmd_args, :opts
 
     should "know its cmd, cmd_args, and opts" do
       assert_equal 'null', subject.cmd_name
       assert_equal [1,2],  subject.cmd_args
       assert_equal 'opts', subject.opts['some']
-    end
-
-    should "default the 'root_path' opt to `Dir.pwd`" do
-      assert_equal Dir.pwd, subject.root_path
-    end
-
-  end
-
-  class RunTests < BaseTests
-    desc "when running a command"
-    setup do
-      @orig_root_path = Dassets.config.root_path
-      Dassets.config.root_path = nil
-      @runner = Dassets::Runner.new(['null', 1, 2], {
-        'root_path' => File.join(ROOT_PATH, 'test', 'support')
-      })
-    end
-    teardown do
-      Dassets.config.root_path = @orig_root_path
-    end
-
-    should "require in the config/dassets.rb file if it exists" do
-      assert_nil Dassets.config.root_path
-      subject.run
-      assert_not_nil Dassets.config.root_path
     end
 
     should "complain about unknown cmds" do


### PR DESCRIPTION
It defaults to `config/assets`.  This gets the Dassets CLI more in-line
with how the Sanford CLI works.  The CLI expects that whatever file
is specified by `ENV['DASSETS_CONFIG_FILE']` configures Dassets
appropriately.

Moving to this design simplified a lot of things and revealed a
whole bunch of "cruft" in the CLI that just wasn't needed.  Good
times.

@jcredding ready for review.
