### PR TITLE
updating the assets file handling to follow the Sanford pattern

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -5,12 +5,15 @@ require 'dassets/version'
 require 'dassets/root_path'
 require 'dassets/digests_file'
 
+ENV['DASSETS_ASSETS_FILE'] ||= 'config/assets'
+
 module Dassets
 
   def self.config; Config; end
   def self.configure(&block); Config.define(&block); end
 
   def self.init
+    require self.config.assets_file
     @digests_file = DigestsFile.new(self.config.digests_file_path)
   end
 
@@ -26,8 +29,9 @@ module Dassets
   class Config
     include NsOptions::Proxy
 
-    option :root_path,  Pathname, :required => true
-    option :files_path, RootPath, :default => proc{ "app/assets/public" }
+    option :assets_file, Pathname, :default => ENV['DASSETS_ASSETS_FILE']
+    option :root_path,   Pathname, :required => true
+    option :files_path,  RootPath, :default => proc{ "app/assets/public" }
     option :digests_file_path, RootPath, :default => proc{ "app/assets/.digests" }
 
   end

--- a/lib/dassets/runner.rb
+++ b/lib/dassets/runner.rb
@@ -1,7 +1,5 @@
 require 'dassets'
 
-ENV['DASSETS_CONFIG_FILE'] ||= 'config/assets'
-
 module Dassets; end
 class Dassets::Runner
   UnknownCmdError = Class.new(ArgumentError)
@@ -17,7 +15,7 @@ class Dassets::Runner
   end
 
   def run
-    require ENV['DASSETS_CONFIG_FILE']
+    Dassets.init
 
     case @cmd_name
     when 'digest'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,7 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
-ENV['DASSETS_TEST_MODE'] = 'yes'
-ENV['DASSETS_CONFIG_FILE'] = 'test/support/config/assets'
-require ENV['DASSETS_CONFIG_FILE']
+ENV['DASSETS_TEST_MODE']   = 'yes'
+ENV['DASSETS_ASSETS_FILE'] = 'test/support/config/assets'
+require 'dassets'
+Dassets.init

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -9,7 +9,8 @@ class Dassets::Config
     desc "Dassets::Config"
     subject{ Dassets::Config }
 
-    should have_option  :root_path, Pathname, :required => true
+    should have_option  :assets_file, Pathname, :default => ENV['DASSETS_ASSETS_FILE']
+    should have_option  :root_path,   Pathname, :required => true
     should have_options :files_path, :digests_file_path
 
     should "should use `apps/assets/public` as the default files path" do


### PR DESCRIPTION
Define a config for the assets file, default it with an ENV var.  Then
require in the assets file on `init`.

This updates Dassets to this pattern - the goal is to be as similar
to Sanford as possible.  The reason for this is they are both
gems, with CLIs, that need some configs in an expected file, and then
do stuff.

@jcredding similar to Ardb - ready for review.
