### PR TITLE
redesign: configuration updates to support full digesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,21 @@ Dassets.configure do |c|
   # tell Dassets what the root path of your app is
   c.root_path '/path/to/app/root'
 
-  # it works best to *not* keep the asset files in your public dir
-  c.files_path '/path/to/not/public' # default: '{root_path}/app/assets/public'
+  # tell Dassets where to write the digests
+  c.digests_path '/path/to/.digests' # default: '{source_path}/.digests'
 
-  # you can choose the file to write the digests to, if you want
-  c.digests_file_path '/path/to/.digests' # default: '{root_path}/app/assets/.digests'
+  # tell Dassets where to look for source files and (optionally) how to filter those files
+  c.source_path 'lib/asset_files' # default: '{root_path}/app/assets'
+  c.source_filter proc{ |paths| paths.select{ |p| ... } }
+  # --OR--
+  c.sources 'lib/asset_files' do |paths|
+    # return the filtered source path list
+    paths.select{ |p| ... }
+  end
+
+  # tell Dassets where to write output files to
+  # it works best to *not* output to your public dir if using fingerprinting
+  c.output_path '/lib/assets_output' # default: '{source_path}/public'
 
 end
 ```

--- a/lib/dassets/runner/cache_command.rb
+++ b/lib/dassets/runner/cache_command.rb
@@ -16,7 +16,7 @@ class Dassets::Runner::CacheCommand
 
     @files_root_path = Pathname.new(Dassets.config.files_path)
     @cache_root_path = Pathname.new(cache_root_path)
-    @digests_file = Dassets::DigestsFile.new(Dassets.config.digests_file_path)
+    @digests_file = Dassets::DigestsFile.new(Dassets.config.digests_path)
     @asset_files = @digests_file.asset_files
   end
 

--- a/lib/dassets/runner/digest_command.rb
+++ b/lib/dassets/runner/digest_command.rb
@@ -10,7 +10,7 @@ class Dassets::Runner::DigestCommand
 
   def initialize(requested_paths)
     @pwd = ENV['PWD']
-    @digests_file = Dassets::DigestsFile.new(Dassets.config.digests_file_path)
+    @digests_file = Dassets::DigestsFile.new(Dassets.config.digests_path)
     @asset_files = @requested_files = get_asset_files(requested_paths || [])
     if @asset_files.empty?
       @asset_files = @current_files = get_asset_files([*Dassets.config.files_path])

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -7,20 +7,48 @@ class Dassets::Config
   class BaseTests < Assert::Context
     include NsOptions::AssertMacros
     desc "Dassets::Config"
-    subject{ Dassets::Config }
+    setup do
+      @config = Dassets::Config.new
+    end
+    subject{ @config }
 
-    should have_option  :assets_file, Pathname, :default => ENV['DASSETS_ASSETS_FILE']
-    should have_option  :root_path,   Pathname, :required => true
-    should have_options :files_path, :digests_file_path
+    should have_option :root_path,   Pathname, :required => true
+    should have_option :assets_file, Pathname, :default => ENV['DASSETS_ASSETS_FILE']
+    should have_options :source_path, :output_path, :digests_path
+    should have_imeth :sources
 
-    should "should use `apps/assets/public` as the default files path" do
+    should "should use `apps/assets` as the default source path" do
+      exp_path = Dassets.config.root_path.join("app/assets").to_s
+      assert_equal exp_path, subject.source_path
+    end
+
+    should "should use `apps/assets/public` as the default output path" do
       exp_path = Dassets.config.root_path.join("app/assets/public").to_s
-      assert_equal exp_path, subject.files_path
+      assert_equal exp_path, subject.output_path
     end
 
     should "should use `app/assets/.digests` as the default digests file path" do
       exp_path = Dassets.config.root_path.join("app/assets/.digests").to_s
-      assert_equal exp_path, subject.digests_file_path
+      assert_equal exp_path, subject.digests_path.to_s
+    end
+
+    should "set the source path and filter proc with the `sources` method" do
+      path = Dassets::RootPath.new 'app/asset_files'
+      filter = proc{ |paths| [] }
+
+      subject.sources(path, &filter)
+      assert_equal path, subject.source_path
+      assert_equal filter, subject.source_filter
+    end
+
+
+
+    # deprecated
+    should have_options :files_path
+
+    should "should use `apps/assets/public` as the default files path" do
+      exp_path = Dassets.config.root_path.join("app/assets/public").to_s
+      assert_equal exp_path, subject.files_path
     end
 
   end

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -10,8 +10,8 @@ module Dassets
 
     should have_imeths :config, :configure, :init, :digests, :[]
 
-    should "return its `Config` class with the `config` method" do
-      assert_same Config, subject.config
+    should "return a `Config` instance with the `config` method" do
+      assert_kind_of Config, subject.config
     end
 
     should "read/parse the digests on init" do


### PR DESCRIPTION
This has a few small changes wrapped up in it.  First, Dassets now
uses a Config _instance_ for storing its configuration (as opposed
to the `Config` singleton directly).  This ensures a clean config
state and allows testing on config instances and not messing with
the singleton state in tests.

Also, this has a few new config values: source_path, output_path,
digests_path.  `digests_path` replaces the deprecated `digests_file_path`.
The other additional configs allow for better source handling and
output generation.

@jcredding ready for review.
