### PR TITLE
Switch to using `config.output_path` instead of deprecated `files_path`

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -61,9 +61,6 @@ module Dassets
       @engines[input_ext.to_s] = engine_class.new(opts)
     end
 
-    # deprecated
-    option :files_path,  RootPath, :default => proc{ "app/assets/public" }
-
   end
 
   class SourceList

--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -6,13 +6,13 @@ module Dassets; end
 class Dassets::AssetFile
 
   def self.from_abs_path(abs_path)
-    rel_path = abs_path.sub("#{Dassets.config.files_path}/", '')
+    rel_path = abs_path.sub("#{Dassets.config.output_path}/", '')
     md5  = Digest::MD5.file(abs_path).hexdigest
     self.new(rel_path, md5)
   end
 
   attr_reader :path, :md5, :dirname, :extname, :basename
-  attr_reader :files_path, :cache_path, :href
+  attr_reader :output_path, :url, :href
 
   def initialize(rel_path, md5)
     @path, @md5 = rel_path, md5
@@ -20,40 +20,41 @@ class Dassets::AssetFile
     @extname  = File.extname(@path)
     @basename = File.basename(@path, @extname)
 
-    file_name = "#{@basename}-#{@md5}#{@extname}"
-    @files_path = File.join(Dassets.config.files_path, @path)
-    @cache_path = File.join(@dirname, file_name).sub(/^\.\//, '').sub(/^\//, '')
-    @href = "/#{@cache_path}"
+    @output_path = File.join(Dassets.config.output_path, @path)
+
+    url_basename = "#{@basename}-#{@md5}#{@extname}"
+    @url = File.join(@dirname, url_basename).sub(/^\.\//, '').sub(/^\//, '')
+    @href = "/#{@url}"
   end
 
   def content
-    @content ||= if File.exists?(@files_path) && File.file?(@files_path)
-      File.read(@files_path)
+    @content ||= if File.exists?(@output_path) && File.file?(@output_path)
+      File.read(@output_path)
     end
   end
 
   def mtime
-    @mtime ||= if File.exists?(@files_path) && File.file?(@files_path)
-      File.mtime(@files_path).httpdate
+    @mtime ||= if File.exists?(@output_path) && File.file?(@output_path)
+      File.mtime(@output_path).httpdate
     end
   end
 
   # We check via File::size? whether this file provides size info via stat,
   # otherwise we have to figure it out by reading the whole file into memory.
   def size
-    @size ||= if File.exists?(@files_path) && File.file?(@files_path)
-      File.size?(@files_path) || Rack::Utils.bytesize(self.content)
+    @size ||= if File.exists?(@output_path) && File.file?(@output_path)
+      File.size?(@output_path) || Rack::Utils.bytesize(self.content)
     end
   end
 
   def mime_type
-    @mime_type ||= if File.exists?(@files_path) && File.file?(@files_path)
+    @mime_type ||= if File.exists?(@output_path) && File.file?(@output_path)
       Rack::Mime.mime_type(@extname)
     end
   end
 
   def exists?
-    File.exists?(@files_path) && File.file?(@files_path)
+    File.exists?(@output_path) && File.file?(@output_path)
   end
 
   def ==(other_asset_file)

--- a/lib/dassets/runner/cache_command.rb
+++ b/lib/dassets/runner/cache_command.rb
@@ -7,28 +7,25 @@ module Dassets; end
 class Dassets::Runner; end
 class Dassets::Runner::CacheCommand
 
-  attr_reader :files_root_path, :cache_root_path, :digests, :asset_files
+  attr_reader :cache_root_path, :output_root_path, :digests, :asset_files
 
   def initialize(cache_root_path)
     unless cache_root_path && File.directory?(cache_root_path)
       raise Dassets::Runner::CmdError, "specify an existing cache directory"
     end
-
-    @files_root_path = Pathname.new(Dassets.config.files_path)
     @cache_root_path = Pathname.new(cache_root_path)
+    @output_root_path = Pathname.new(Dassets.config.output_path)
     @digests = Dassets::Digests.new(Dassets.config.digests_path)
     @asset_files = @digests.asset_files
   end
 
-  def run(write_files=true)
+  def run(write_files=true) # TODO: pass in io to write to
     begin
       @asset_files.each do |file|
-        files_path = @files_root_path.join(file.path).to_s
-        cache_path = @cache_root_path.join(file.cache_path).to_s
-
+        cache_path = @cache_root_path.join(file.url).to_s
         if write_files
           FileUtils.mkdir_p File.dirname(cache_path)
-          FileUtils.cp(files_path, cache_path)
+          FileUtils.cp(file.output_path, cache_path)
         end
       end
       unless ENV['DASSETS_TEST_MODE']

--- a/lib/dassets/runner/digest_command.rb
+++ b/lib/dassets/runner/digest_command.rb
@@ -13,7 +13,7 @@ class Dassets::Runner::DigestCommand
     @digests = Dassets::Digests.new(Dassets.config.digests_path)
     @asset_files = @requested_files = get_asset_files(requested_paths || [])
     if @asset_files.empty?
-      @asset_files = @current_files = get_asset_files([*Dassets.config.files_path])
+      @asset_files = @current_files = get_asset_files([*Dassets.config.output_path])
     end
   end
 
@@ -48,7 +48,7 @@ class Dassets::Runner::DigestCommand
   end
 
   # Get all file paths fuzzy-matching the given paths.  Each path must be a
-  # file that exists and is in the `config.files_path` tree.  Return them
+  # file that exists and is in the `config.output_path` tree.  Return them
   # as sorted AssetFile objects.
   def get_asset_files(paths)
     fuzzy_paths(paths).
@@ -65,7 +65,7 @@ class Dassets::Runner::DigestCommand
   end
 
   def is_asset_file?(path)
-    File.file?(path) && path.include?("#{Dassets.config.files_path}/")
+    File.file?(path) && path.include?("#{Dassets.config.output_path}/")
   end
 
 end

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -12,7 +12,7 @@ class Dassets::AssetFile
 
     should have_cmeths :from_abs_path
     should have_readers :path, :md5, :dirname, :extname, :basename
-    should have_readers :files_path, :cache_path, :href
+    should have_readers :output_path, :url, :href
     should have_imeth :content, :mtime, :size, :mime_type, :exists?, :==
 
     should "know its given path and md5" do
@@ -26,21 +26,21 @@ class Dassets::AssetFile
       assert_equal 'file1', subject.basename
     end
 
-    should "build it's files_path from the path" do
-      assert_equal "#{Dassets.config.files_path}/file1.txt", subject.files_path
+    should "build it's output_path from the path" do
+      assert_equal "#{Dassets.config.output_path}/file1.txt", subject.output_path
 
       nested = Dassets::AssetFile.new('nested/file1.txt', 'abc123')
-      assert_equal "#{Dassets.config.files_path}/nested/file1.txt", nested.files_path
+      assert_equal "#{Dassets.config.output_path}/nested/file1.txt", nested.output_path
     end
 
-    should "build it's cache_path from the path and the md5" do
-      assert_equal "file1-abc123.txt", subject.cache_path
+    should "build it's url from the path and the md5" do
+      assert_equal "file1-abc123.txt", subject.url
 
       nested = Dassets::AssetFile.new('nested/file1.txt', 'abc123')
-      assert_equal "nested/file1-abc123.txt", nested.cache_path
+      assert_equal "nested/file1-abc123.txt", nested.url
     end
 
-    should "build it's href from the cache path" do
+    should "build it's href from the url" do
       assert_equal "/file1-abc123.txt", subject.href
 
       nested = Dassets::AssetFile.new('nested/file1.txt', 'abc123')
@@ -48,7 +48,7 @@ class Dassets::AssetFile
     end
 
     should "be created from absolute file paths and have md5 computed" do
-      abs_file_path = File.join(Dassets.config.files_path, 'file1.txt')
+      abs_file_path = File.join(Dassets.config.output_path, 'file1.txt')
       exp_md5 = 'daa05c683a4913b268653f7a7e36a5b4'
       file = Dassets::AssetFile.from_abs_path(abs_file_path)
 
@@ -58,8 +58,8 @@ class Dassets::AssetFile
 
     should "know it's content, mtime, size, mime_type, and if it exists" do
       assert_equal "file1.txt\n", subject.content
-      assert_equal File.mtime(subject.files_path).httpdate, subject.mtime
-      assert_equal File.size?(subject.files_path), subject.size
+      assert_equal File.mtime(subject.output_path).httpdate, subject.mtime
+      assert_equal File.size?(subject.output_path), subject.size
       assert_equal "text/plain", subject.mime_type
       assert subject.exists?
 

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -63,13 +63,9 @@ class Dassets::Config
       assert_equal '', subject.engines['empty'].compile('some content')
     end
 
-
-    # deprecated
-    should have_options :files_path
-
     should "should use `apps/assets/public` as the default files path" do
       exp_path = Dassets.config.root_path.join("app/assets/public").to_s
-      assert_equal exp_path, subject.files_path
+      assert_equal exp_path, subject.output_path
     end
 
   end

--- a/test/unit/runner/cache_command_tests.rb
+++ b/test/unit/runner/cache_command_tests.rb
@@ -16,10 +16,10 @@ class Dassets::Runner::CacheCommand
     end
     subject{ @cmd }
 
-    should have_readers :files_root_path, :cache_root_path, :digests, :asset_files
+    should have_readers :cache_root_path, :output_root_path, :digests, :asset_files
 
     should "use the config's files path and its files root path" do
-      assert_equal Dassets.config.files_path, subject.files_root_path.to_s
+      assert_equal Dassets.config.output_path, subject.output_root_path.to_s
     end
 
     should "know its given cache root path" do
@@ -53,7 +53,7 @@ class Dassets::Runner::CacheCommand
 
       assert_file_exists @cache_root_path.to_s
       subject.asset_files.each do |file|
-        assert_file_exists File.join(@cache_root_path, file.cache_path)
+        assert_file_exists File.join(@cache_root_path, file.url)
       end
     end
 

--- a/test/unit/runner/digest_command_tests.rb
+++ b/test/unit/runner/digest_command_tests.rb
@@ -22,7 +22,7 @@ class Dassets::Runner::DigestCommand
     end
 
     should "get it's asset files from the args if passed" do
-      path_string = File.join(Dassets.config.files_path, 'file*')
+      path_string = File.join(Dassets.config.output_path, 'file*')
       digest_cmd  = Dassets::Runner::DigestCommand.new([path_string])
 
       assert_equal 2, digest_cmd.asset_files.size
@@ -41,9 +41,9 @@ class Dassets::Runner::DigestCommand
       @addfile = 'addfile.txt'
       @rmfile  = 'file1.txt'
       @updfile = 'file2.txt'
-      @addfile_path = File.join(File.join(Dassets.config.files_path, @addfile))
-      @rmfile_path  = File.join(File.join(Dassets.config.files_path, @rmfile))
-      @updfile_path = File.join(File.join(Dassets.config.files_path, @updfile))
+      @addfile_path = File.join(File.join(Dassets.config.output_path, @addfile))
+      @rmfile_path  = File.join(File.join(Dassets.config.output_path, @rmfile))
+      @updfile_path = File.join(File.join(Dassets.config.output_path, @updfile))
 
       @rmfilecontents   = File.read(@rmfile_path)
       @updfilecontents  = File.read(@updfile_path)

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -16,7 +16,7 @@ class Dassets::Server::Response
 
     should "handle not modified files" do
       af = Dassets['file1.txt']
-      mtime = File.mtime(af.files_path).httpdate.to_s
+      mtime = File.mtime(af.output_path).httpdate.to_s
       resp = file_response(af, 'HTTP_IF_MODIFIED_SINCE' => mtime)
 
       assert_equal 304, resp.status
@@ -30,8 +30,8 @@ class Dassets::Server::Response
       resp = file_response(af)
       exp_headers = {
         'Content-Type'   => 'text/plain',
-        'Content-Length' => File.size?(af.files_path).to_s,
-        'Last-Modified'  => File.mtime(af.files_path).httpdate.to_s
+        'Content-Length' => File.size?(af.output_path).to_s,
+        'Last-Modified'  => File.mtime(af.output_path).httpdate.to_s
       }
 
       assert_equal 200, resp.status


### PR DESCRIPTION
This rename and reuse more aptly describes the nature of the files
in play.  These are the files that have been output by the digest
process.

In addition, this renames the asset file `cache_path` property to
`url`.  Cache path really doesn't describe the intent of this property
from the asset file's perspective.  From the asset file's perspective
this property is the URL used to compose the files `href`.  What
you do with the property (ie use it to cache or whatever) is not the
asset file's concern.

@jcredding a whole bunch of renames - ready for review.
