### PR TITLE
redesign: source file `digest` method

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -11,21 +11,23 @@ ENV['DASSETS_ASSETS_FILE'] ||= 'config/assets'
 
 module Dassets
 
-  def self.config; @config ||= Config.new; end
-  def self.configure(&block); self.config.define(&block); end
+  def self.config;  @config  ||= Config.new;      end
+  def self.sources; @sources ||= Set.new;         end
+  def self.digests; @digests ||= NullDigests.new; end
 
-  def self.init
-    require self.config.assets_file
-    @sources = SourceList.new(self.config)
-    @digests = Digests.new(self.config.digests_path)
+  def self.configure(&block)
+    block.call(self.config)
   end
 
   def self.reset
     @sources = @digests = nil
   end
 
-  def self.sources; @sources || Set.new;         end
-  def self.digests; @digests || NullDigests.new; end
+  def self.init
+    require self.config.assets_file
+    @sources = SourceList.new(self.config)
+    @digests = Digests.new(self.config.digests_path)
+  end
 
   def self.[](asset_path)
     self.digests.asset_file(asset_path)

--- a/test/support/config/assets.rb
+++ b/test/support/config/assets.rb
@@ -1,7 +1,18 @@
 require 'dassets'
 
+@dumb_engine = Class.new(Dassets::Engine) do
+  def ext(in_ext); ''; end
+  def compile(input); "#{input}\nDUMB"; end
+end
+@useless_engine = Class.new(Dassets::Engine) do
+  def ext(in_ext); 'no-use'; end
+  def compile(input); "#{input}\nUSELESS"; end
+end
+
 Dassets.configure do |c|
   c.root_path File.expand_path("../..", __FILE__)
 
-end
+  c.engine 'dumb', @dumb_engine
+  c.engine 'useless', @useless_engine
 
+end


### PR DESCRIPTION
This method digests a source file, meaning it compiles its content,
saves it to the output path, and updates/saves its fingerprint in
the digests file.

@jcredding ready for review.
