### PR TITLE
rename asset file `md5` to `fingerprint`

### DIFF
--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -5,16 +5,10 @@ require 'dassets/source_file'
 module Dassets; end
 class Dassets::AssetFile
 
-  def self.from_abs_path(abs_path)
-    rel_path = abs_path.sub("#{Dassets.config.output_path}/", '')
-    md5  = Digest::MD5.file(abs_path).hexdigest
-    self.new(rel_path, md5)
-  end
-
   attr_reader :path, :dirname, :extname, :basename, :output_path
 
-  def initialize(digest_path, md5=nil)
-    @path, @md5 = digest_path, md5
+  def initialize(digest_path, fingerprint=nil)
+    @path, @fingerprint = digest_path, fingerprint
     @dirname  = File.dirname(@path)
     @extname  = File.extname(@path)
     @basename = File.basename(@path, @extname)
@@ -25,8 +19,8 @@ class Dassets::AssetFile
     @source_file ||= Dassets::SourceFile.find_by_digest_path(path)
   end
 
-  def md5
-    @md5 ||= self.source_file.fingerprint
+  def fingerprint
+    @fingerprint ||= self.source_file.fingerprint
   end
 
   def content
@@ -39,7 +33,7 @@ class Dassets::AssetFile
 
   def url
     @url ||= begin
-      url_basename = "#{@basename}-#{self.md5}#{@extname}"
+      url_basename = "#{@basename}-#{self.fingerprint}#{@extname}"
       File.join(@dirname, url_basename).sub(/^\.\//, '').sub(/^\//, '')
     end
   end
@@ -75,7 +69,7 @@ class Dassets::AssetFile
   def ==(other_asset_file)
     other_asset_file.kind_of?(Dassets::AssetFile) &&
     self.path == other_asset_file.path &&
-    self.md5 == other_asset_file.md5
+    self.fingerprint == other_asset_file.fingerprint
   end
 
 end

--- a/lib/dassets/digests.rb
+++ b/lib/dassets/digests.rb
@@ -37,8 +37,11 @@ module Dassets
       Hash.new.tap do |h|
         if File.exists?(file_path)
           File.open(file_path, 'r').each_line do |l|
-            path, md5 = l.split(','); path ||= ''; path.strip!; md5 ||= ''; md5.strip!
-            h[path] = md5 if !path.empty?
+            path, fprint = l.split(',')
+            path   ||= ''; path.strip!
+            fprint ||= ''; fprint.strip!
+
+            h[path] = fprint if !path.empty?
           end
         end
       end

--- a/test/system/digest_cmd_run_tests.rb
+++ b/test/system/digest_cmd_run_tests.rb
@@ -20,7 +20,7 @@ module Dassets
 
       @rmfilecontents   = File.read(@rmfile_path)
       @updfilecontents  = File.read(@updfile_path)
-      @orig_updfile_md5 = Dassets.digests[@updfile]
+      @orig_updfile_fprint = Dassets.digests[@updfile]
 
       FileUtils.touch @addfile_path
       FileUtils.rm @rmfile_path
@@ -41,7 +41,7 @@ module Dassets
       assert_equal 5, Dassets.digests.paths.size
       assert_not_includes @addfile, Dassets.digests.paths
       assert_includes @rmfile, Dassets.digests.paths
-      assert_equal @orig_updfile_md5, Dassets.digests[@updfile]
+      assert_equal @orig_updfile_fprint, Dassets.digests[@updfile]
 
       Dassets.digest_source_files
 
@@ -49,7 +49,7 @@ module Dassets
       assert_equal 5, Dassets.digests.paths.size
       assert_includes @addfile, Dassets.digests.paths
       assert_not_includes @rmfile, Dassets.digests.paths
-      assert_not_equal @orig_updfile_md5, Dassets.digests[@updfile]
+      assert_not_equal @orig_updfile_fprint, Dassets.digests[@updfile]
     end
 
     should "update the digests on a single source file when given its path" do
@@ -62,7 +62,7 @@ module Dassets
       assert_equal 6, Dassets.digests.paths.size
       assert_includes @addfile, Dassets.digests.paths
       assert_includes @rmfile, Dassets.digests.paths
-      assert_equal    @orig_updfile_md5, Dassets.digests[@updfile]
+      assert_equal    @orig_updfile_fprint, Dassets.digests[@updfile]
     end
 
   end

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -12,9 +12,8 @@ class Dassets::AssetFile
     end
     subject{ @asset_file }
 
-    should have_cmeths  :from_abs_path
     should have_readers :path, :dirname, :extname, :basename, :output_path
-    should have_imeths  :md5, :content, :url, :href, :source_file
+    should have_imeths  :fingerprint, :content, :url, :href, :source_file
     should have_imeths  :mtime, :size, :mime_type, :exists?, :==
 
     should "know its digest path, dirname, extname, and basename" do
@@ -50,13 +49,13 @@ class Dassets::AssetFile
       assert_equal subject.path, subject.source_file.digest_path
     end
 
-    should "know its md5" do
-      assert_equal 'abc123', subject.md5
+    should "know its fingerprint" do
+      assert_equal 'abc123', subject.fingerprint
     end
 
-    should "get its md5 from its source file if none is given" do
+    should "get its fingerprint from its source file if none is given" do
       af = Dassets::AssetFile.new('file1.txt')
-      assert_equal af.source_file.fingerprint, af.md5
+      assert_equal af.source_file.fingerprint, af.fingerprint
     end
 
     should "know it's content" do
@@ -79,7 +78,7 @@ class Dassets::AssetFile
       FileUtils.mv "#{with_output.output_path}.bak", with_output.output_path
     end
 
-    should "build it's url from the path and the md5" do
+    should "build it's url from the path and the fingerprint" do
       assert_equal "file1-abc123.txt", subject.url
 
       nested = Dassets::AssetFile.new('nested/file1.txt', 'abc123')
@@ -91,15 +90,6 @@ class Dassets::AssetFile
 
       nested = Dassets::AssetFile.new('nested/file1.txt', 'abc123')
       assert_equal "/nested/file1-abc123.txt", nested.href
-    end
-
-    should "be created from absolute file paths and have its md5 computed" do
-      abs_file_path = File.join(Dassets.config.output_path, 'file1.txt')
-      exp_md5 = 'daa05c683a4913b268653f7a7e36a5b4'
-      file = Dassets::AssetFile.from_abs_path(abs_file_path)
-
-      assert_equal 'file1.txt', file.path
-      assert_equal exp_md5, file.md5
     end
 
   end

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -38,18 +38,18 @@ module Dassets
 
       assert_kind_of Dassets::AssetFile, file
       assert_equal 'nested/file3.txt', file.path
-      assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.md5
+      assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.fingerprint
 
       subject.reset
     end
 
     should "return an asset file with no fingerprint if path not in digests" do
       file = subject['path/not/found.txt']
-      assert_equal '', file.md5
+      assert_equal '', file.fingerprint
 
       subject.init
       file = subject['path/not/found.txt']
-      assert_equal '', file.md5
+      assert_equal '', file.fingerprint
 
       subject.reset
     end

--- a/test/unit/digests_tests.rb
+++ b/test/unit/digests_tests.rb
@@ -31,7 +31,7 @@ class Dassets::Digests
 
       assert_kind_of Dassets::AssetFile, file
       assert_equal 'path/to/file1', file.path
-      assert_equal subject['path/to/file1'], file.md5
+      assert_equal subject['path/to/file1'], file.fingerprint
     end
 
     should "read values with the index operator" do

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -25,23 +25,23 @@ class Dassets::Server::Request
     end
 
     should "know if it is for an asset file" do
-      # find nested path with matching md5
+      # find nested path with matching fingerprint
       req = file_request('GET', '/nested/file3-d41d8cd98f00b204e9800998ecf8427e.txt')
       assert req.for_asset_file?
 
-      # find not nested path with matching md5
+      # find not nested path with matching fingerprint
       req = file_request('HEAD', '/file1-daa05c683a4913b268653f7a7e36a5b4.txt')
       assert req.for_asset_file?
 
-      # find even if md5 is *not* matching - just need to have any md5
+      # find even if fingerprint is *not* matching - just need to have any fingerprint
       req = file_request('GET', '/file1-d41d8cd98f00b204e9800998ecf8427e.txt')
       assert req.for_asset_file?
 
-      # no find on invalid md5
+      # no find on invalid fingerprint
       req = file_request('GET', '/file1-daa05c683a4913b268653f7a7e36a.txt')
       assert_not req.for_asset_file?
 
-      # no find on missing md5
+      # no find on missing fingerprint
       req = file_request('HEAD', '/file1.txt')
       assert_not req.for_asset_file?
 
@@ -49,7 +49,7 @@ class Dassets::Server::Request
       req = file_request('GET', '/some-file.txt')
       assert_not req.for_asset_file?
 
-      # no find on unknown file with an md5
+      # no find on unknown file with an fingerprint
       req = file_request('GET', '/some-file-daa05c683a4913b268653f7a7e36a5b4.txt')
       assert_not req.for_asset_file?
     end


### PR DESCRIPTION
No need to name the attr after the algorithm used to create it.  A
more appropriate name is "fingerprint" - it doesn't matter how you
compute that fingerprint.

This will allow us to more easily alter the method we use compute
file fingerprints and is a more appropriate name.

Also included here: I removed the `AssetFile.from_abs_path` class
method.  It is no longer being used and needed to be cleaned up.

@jcredding ready for review.
