### PR TITLE
removing a bunch of source handling that has proven unnecessary

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -12,19 +12,12 @@ ENV['DASSETS_ASSETS_FILE'] ||= 'config/assets'
 module Dassets
 
   def self.config;  @config  ||= Config.new; end
-  def self.sources; @sources ||= Set.new;    end
-
   def self.configure(&block)
     block.call(self.config)
   end
 
-  def self.reset
-    @sources = nil
-  end
-
   def self.init
     require self.config.assets_file
-    @sources = SourceList.new(self.config)
   end
 
   def self.[](digest_path)

--- a/test/system/digest_cmd_run_tests.rb
+++ b/test/system/digest_cmd_run_tests.rb
@@ -9,8 +9,6 @@ module Dassets
     setup do
       Dassets.config.output_path = 'public'
       clear_output_path(Dassets.config.output_path)
-      Dassets.reset
-      Dassets.init
       Dassets.digest_source_files
 
       @addfile = 'addfile.txt'
@@ -30,8 +28,6 @@ module Dassets
       File.open(@rmfile_src,  "w"){ |f| f.write @rmfile_contents }
       FileUtils.rm @addfile_src
 
-      Dassets.reset
-      Dassets.init
       Dassets.digest_source_files
       clear_output_path(Dassets.config.output_path)
       Dassets.digest_source_files

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -10,11 +10,7 @@ module Dassets
 
     desc "the middleware in a rack app"
     setup do
-      Dassets.init
       app.use Dassets::Server
-    end
-    teardown do
-      Dassets.reset
     end
 
     def app

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -8,31 +8,19 @@ module Dassets
     desc "Dassets"
     subject{ Dassets }
 
-    should have_imeths :config, :sources
-    should have_imeths :configure, :reset, :init, :[]
+    should have_imeths :config, :configure, :init, :[]
     should have_imeths :digest_source_files
 
     should "return a `Config` instance with the `config` method" do
       assert_kind_of Config, subject.config
     end
 
-    should "read the source list on init" do
-      subject.reset
-      assert_empty subject.sources
-
-      subject.init
-      assert_not_empty subject.sources
-    end
-
     should "return asset files given a their digest path using the index operator" do
-      subject.init
       file = subject['nested/file3.txt']
 
       assert_kind_of Dassets::AssetFile, file
       assert_equal 'nested/file3.txt', file.path
       assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.fingerprint
-
-      subject.reset
     end
 
     should "return an asset file with unknown source if digest path not found" do

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -6,11 +6,7 @@ class Dassets::Server::Request
   class BaseTests < Assert::Context
     desc "Dassets::Server::Request"
     setup do
-      Dassets.init
       @req = file_request('GET', '/file1-daa05c683a4913b268653f7a7e36a5b4.txt')
-    end
-    teardown do
-      Dassets.reset
     end
     subject{ @req }
 

--- a/test/unit/source_file_tests.rb
+++ b/test/unit/source_file_tests.rb
@@ -81,13 +81,11 @@ class Dassets::SourceFile
   class DigestTests < EngineTests
     desc "being digested with an output path configured"
     setup do
-      Dassets.init
       Dassets.config.output_path = 'public'
       @digested_asset_file = @source_file.digest
     end
     teardown do
       Dassets.config.output_path = nil
-      Dassets.reset
     end
 
     should "return the digested asset file" do


### PR DESCRIPTION
Don't need any source processing on init - it is all done on demand
by the middleware and digest cmd.  This removes the need to "reset"
Dassets global state as well.

@jcredding ready for review.
