### PR TITLE
move the 'digest' method off of the source file and onto the asset file

### DIFF
--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -16,12 +16,15 @@ class Dassets::AssetFile
     @source_file = Dassets::SourceFile.find_by_digest_path(path)
   end
 
-  def fingerprint
-    @fingerprint ||= @source_file.fingerprint
-  end
-
-  def content
-    @content ||= @source_file.compiled
+  def digest!
+    return if !self.exists?
+    # TODO: Dassets.config.file_store.save(self.url) { self.content }
+    if File.exists?(op = Dassets.config.output_path.to_s)
+      file_output_path = File.join(op, self.url)
+      FileUtils.mkdir_p(File.dirname(file_output_path))
+      File.open(file_output_path, "w"){ |f| f.write(self.content) }
+    end
+    self.url
   end
 
   def url
@@ -31,22 +34,30 @@ class Dassets::AssetFile
     end
   end
 
+  def fingerprint
+    @fingerprint ||= @source_file.fingerprint
+  end
+
+  def content
+    @content ||= @source_file.compiled
+  end
+
   def href
     @href ||= "/#{self.url}"
   end
 
   def mtime
-    return nil if !@source_file.exists?
+    return nil if !self.exists?
     @mtime ||= @source_file.mtime
   end
 
   def size
-    return nil if !@source_file.exists?
+    return nil if !self.exists?
     @size ||= Rack::Utils.bytesize(self.content)
   end
 
   def mime_type
-    return nil if !@source_file.exists?
+    return nil if !self.exists?
     @mime_type ||= Rack::Mime.mime_type(@extname)
   end
 

--- a/lib/dassets/digest_cmd.rb
+++ b/lib/dassets/digest_cmd.rb
@@ -25,7 +25,7 @@ class Dassets::DigestCmd
   private
 
   def digest_the_files(files)
-    files.map{ |f| Dassets::SourceFile.new(f).digest }
+    files.each{ |f| Dassets::SourceFile.new(f).asset_file.digest! }
   end
 
   def log(io, msg)

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -41,18 +41,6 @@ module Dassets
       end
     end
 
-    def digest
-      return if !self.exists?
-
-      self.asset_file.tap do |af|
-        if File.exists?(op = Dassets.config.output_path.to_s)
-          file_output_path = File.join(op, af.url)
-          FileUtils.mkdir_p(File.dirname(file_output_path))
-          File.open(file_output_path, "w"){ |f| f.write(self.compiled) }
-        end
-      end
-    end
-
     def compiled
       @compiled ||= @ext_list.inject(read_file(@file_path)) do |content, ext|
         Dassets.config.engines[ext].compile(content)

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -13,8 +13,8 @@ class Dassets::AssetFile
     subject{ @asset_file }
 
     should have_readers :path, :dirname, :extname, :basename, :source_file
-    should have_imeths  :fingerprint, :content, :url, :href
-    should have_imeths  :mtime, :size, :mime_type, :exists?, :==
+    should have_imeths  :digest!, :url, :fingerprint, :content
+    should have_imeths  :href, :mtime, :size, :mime_type, :exists?, :==
 
     should "know its digest path, dirname, extname, and basename" do
       assert_equal 'file1.txt', subject.path
@@ -78,6 +78,29 @@ class Dassets::AssetFile
 
       nested = Dassets::AssetFile.new('nested/file1.txt')
       assert_equal "/nested/file1-.txt", nested.href
+    end
+
+  end
+
+  class DigestTests < BaseTests
+    desc "being digested with an output path configured"
+    setup do
+      Dassets.config.output_path = 'public'
+      @url = @asset_file.digest!
+    end
+    teardown do
+      Dassets.config.output_path = nil
+    end
+
+    should "return the asset file url" do
+      assert_equal @asset_file.url, @url
+    end
+
+    should "compile and write an asset file to the output path" do
+      outfile = File.join(Dassets.config.output_path, @url)
+
+      assert_file_exists outfile
+      assert_equal subject.content, File.read(outfile)
     end
 
   end

--- a/test/unit/source_file_tests.rb
+++ b/test/unit/source_file_tests.rb
@@ -13,7 +13,7 @@ class Dassets::SourceFile
     subject{ @source_file }
 
     should have_readers :file_path
-    should have_imeths :asset_file, :digest_path, :digest
+    should have_imeths :asset_file, :digest_path
     should have_imeths :compiled, :fingerprint, :exists?, :mtime
     should have_cmeth :find_by_digest_path
 
@@ -74,30 +74,6 @@ class Dassets::SourceFile
       file_content = File.read(@file_path)
       exp_compiled_content = [ file_content, 'DUMB', 'USELESS' ].join("\n")
       assert_equal exp_compiled_content, subject.compiled
-    end
-
-  end
-
-  class DigestTests < EngineTests
-    desc "being digested with an output path configured"
-    setup do
-      Dassets.config.output_path = 'public'
-      @digested_asset_file = @source_file.digest
-    end
-    teardown do
-      Dassets.config.output_path = nil
-    end
-
-    should "return the digested asset file" do
-      assert_not_nil @digested_asset_file
-      assert_kind_of Dassets::AssetFile, @digested_asset_file
-    end
-
-    should "compile and write an asset file to the output path" do
-      outfile = File.join(Dassets.config.output_path, subject.asset_file.url)
-
-      assert_file_exists outfile
-      assert_equal subject.compiled, File.read(outfile)
     end
 
   end


### PR DESCRIPTION
Fits better on this model.  Sets up the future file store pattern
for handling writing output files.

No major behavior change - just moving logic to a more appropriate
location - a reorg.

@jcredding ready for review
