### PR TITLE
use a thread-safe file store implementation for writing digested asset files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Dassets.configure do |c|
     paths.select{ |p| ... }
   end
 
-  # (optional) tell Dassets where to write digested asset files
+  # (optional) tell Dassets where to store digested asset files
   # if none given, Dassets will not write any digested output
   # use this to "cache" digested assets to the public dir (for example)
-  c.output_path 'public' # default: `nil`
+  c.file_store 'public' # default: `NullFileStore.new`
 
 end
 ```

--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -4,6 +4,7 @@ require 'ns-options'
 
 require 'dassets/version'
 require 'dassets/root_path'
+require 'dassets/file_store'
 require 'dassets/asset_file'
 require 'dassets/engine'
 
@@ -34,12 +35,11 @@ module Dassets
   class Config
     include NsOptions::Proxy
 
-    option :root_path,    Pathname, :required => true
-    option :output_path,  RootPath, :required => true
-
-    option :assets_file,  Pathname, :default => ENV['DASSETS_ASSETS_FILE']
-    option :source_path,  RootPath, :default => proc{ "app/assets" }
-    option :source_filter, Proc, :default => proc{ |paths| paths }
+    option :root_path,     Pathname,  :required => true
+    option :assets_file,   Pathname,  :default => ENV['DASSETS_ASSETS_FILE']
+    option :source_path,   RootPath,  :default => proc{ "app/assets" }
+    option :source_filter, Proc,      :default => proc{ |paths| paths }
+    option :file_store,    FileStore, :default => proc{ NullFileStore.new }
 
     attr_reader :engines
 
@@ -63,7 +63,6 @@ module Dassets
       paths = Set.new
       paths += Dir.glob(File.join(config.source_path, "**/*"))
       paths.reject!{ |path| !File.file?(path) }
-      paths.reject!{ |path| path =~ /^#{config.output_path}/ } if config.output_path
 
       config.source_filter.call(paths).sort
     end

--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -18,13 +18,7 @@ class Dassets::AssetFile
 
   def digest!
     return if !self.exists?
-    # TODO: Dassets.config.file_store.save(self.url) { self.content }
-    if File.exists?(op = Dassets.config.output_path.to_s)
-      file_output_path = File.join(op, self.url)
-      FileUtils.mkdir_p(File.dirname(file_output_path))
-      File.open(file_output_path, "w"){ |f| f.write(self.content) }
-    end
-    self.url
+    Dassets.config.file_store.save(self.url){ self.content }
   end
 
   def url

--- a/lib/dassets/file_store.rb
+++ b/lib/dassets/file_store.rb
@@ -1,0 +1,37 @@
+module Dassets
+
+  class FileStore
+
+    attr_reader :root
+
+    def initialize(root)
+      @root = RootPath.new(root)
+      @save_mutex = Mutex.new
+    end
+
+    def save(url, &block)
+      @save_mutex.synchronize do
+        store_path(url).tap do |path|
+          FileUtils.mkdir_p(File.dirname(path))
+          File.open(path, "w"){ |f| f.write(block.call) }
+        end
+      end
+    end
+
+    def store_path(url)
+      File.join(@root, url)
+    end
+
+  end
+
+  class NullFileStore < FileStore
+    def initialize
+      super('')
+    end
+
+    def save(url, &block)
+      store_path(url) # no-op, just return the store path like the base does
+    end
+  end
+
+end

--- a/test/system/digest_cmd_run_tests.rb
+++ b/test/system/digest_cmd_run_tests.rb
@@ -7,8 +7,8 @@ module Dassets
   class DigestCmdRunTests < Assert::Context
     desc "the DigestCmd"
     setup do
-      Dassets.config.output_path = 'public'
-      clear_output_path(Dassets.config.output_path)
+      Dassets.config.file_store = 'public'
+      clear_store_path(Dassets.config.file_store.root)
       Dassets.digest_source_files
 
       @addfile = 'addfile.txt'
@@ -19,9 +19,9 @@ module Dassets
       @rmfile_contents = File.read(@rmfile_src)
 
       FileUtils.touch @addfile_src
-      @addfile_out = output_path(@addfile)
+      @addfile_out = store_path(@addfile)
 
-      @rmfile_out = output_path(@rmfile)
+      @rmfile_out = store_path(@rmfile)
       FileUtils.rm @rmfile_src
     end
     teardown do
@@ -29,13 +29,13 @@ module Dassets
       FileUtils.rm @addfile_src
 
       Dassets.digest_source_files
-      clear_output_path(Dassets.config.output_path)
+      clear_store_path(Dassets.config.file_store.root)
       Dassets.digest_source_files
-      Dassets.config.output_path = nil
+      Dassets.config.file_store = NullFileStore.new
     end
 
     should "update the digests on all source files when run with no given paths" do
-      clear_output_path(Dassets.config.output_path)
+      clear_store_path(Dassets.config.file_store.root)
       Dassets.digest_source_files
 
       assert_file_exists @addfile_out
@@ -43,7 +43,7 @@ module Dassets
     end
 
     should "update the digests on a single source file when given its path" do
-      clear_output_path(Dassets.config.output_path)
+      clear_store_path(Dassets.config.file_store.root)
       Dassets.digest_source_files([@addfile_src])
 
       assert_file_exists @addfile_out
@@ -55,11 +55,11 @@ module Dassets
       File.join(File.join(Dassets.config.source_path, file))
     end
 
-    def output_path(file)
-      File.join(Dassets.config.output_path, Dassets::AssetFile.new(file).url)
+    def store_path(file)
+      Dassets.config.file_store.store_path(Dassets::AssetFile.new(file).url)
     end
 
-    def clear_output_path(path)
+    def clear_store_path(path)
       Dir.glob(File.join(path, '*')).each{ |p| FileUtils.rm_r(p) } if path
     end
 

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'fileutils'
 require 'dassets/source_file'
+require 'dassets/file_store'
 require 'dassets/asset_file'
 
 class Dassets::AssetFile
@@ -85,22 +86,21 @@ class Dassets::AssetFile
   class DigestTests < BaseTests
     desc "being digested with an output path configured"
     setup do
-      Dassets.config.output_path = 'public'
-      @url = @asset_file.digest!
+      Dassets.config.file_store = 'public'
+      @save_path = @asset_file.digest!
+      @outfile = Dassets.config.file_store.store_path(@asset_file.url)
     end
     teardown do
-      Dassets.config.output_path = nil
+      Dassets.config.file_store = Dassets::NullFileStore.new
     end
 
     should "return the asset file url" do
-      assert_equal @asset_file.url, @url
+      assert_equal @outfile, @save_path
     end
 
     should "compile and write an asset file to the output path" do
-      outfile = File.join(Dassets.config.output_path, @url)
-
-      assert_file_exists outfile
-      assert_equal subject.content, File.read(outfile)
+      assert_file_exists @outfile
+      assert_equal subject.content, File.read(@outfile)
     end
 
   end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -12,9 +12,10 @@ class Dassets::Config
     end
     subject{ @config }
 
-    should have_option :root_path,   Pathname, :required => true
+    should have_option :root_path, Pathname, :required => true
     should have_option :assets_file, Pathname, :default => ENV['DASSETS_ASSETS_FILE']
-    should have_options :source_path, :output_path
+    should have_options :source_path, :source_filter, :file_store
+
     should have_reader :engines
     should have_imeth :source, :engine
 

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -45,17 +45,6 @@ module Dassets
       assert_equal exp_list, Dassets::SourceList.new(config)
     end
 
-    should "filter out any paths in the output path" do
-      config = Dassets::Config.new
-      config.source_path = "source_files" # test/support/source_files
-      config.output_path = "source_files/nested"
-      exp_list = [
-        'test1.txt', '_ignored.txt'
-      ].map{ |p| File.expand_path(p, config.source_path) }.sort
-
-      assert_equal exp_list, Dassets::SourceList.new(config)
-    end
-
     should "run the supplied source filter on the paths" do
       config = Dassets::Config.new
       config.source_path = "source_files" # test/support/source_files

--- a/test/unit/file_store_tests.rb
+++ b/test/unit/file_store_tests.rb
@@ -1,0 +1,30 @@
+require 'assert'
+require 'dassets/root_path'
+require 'dassets/file_store'
+
+class Dassets::FileStore
+
+  class BaseTests < Assert::Context
+    desc "Dassets::NullFileStore"
+    subject{ Dassets::NullFileStore.new }
+
+    should have_reader :root
+    should have_imeths :save, :store_path
+
+    should "be a kind of FileStore" do
+      assert_kind_of Dassets::FileStore, subject
+    end
+
+    should "build its root based on the config's root_path" do
+      assert_equal Dassets::RootPath.new(''), subject.root
+    end
+
+    should "build the store path based on a given url" do
+    end
+
+    should "return the store path on save" do
+    end
+
+  end
+
+end


### PR DESCRIPTION
By default, a null store is used which means no files will be
written.  Config a file store path to enable writing digested files
in a thread-safe manner.

@jcredding this effectively puts in the null pattern on digesting asset files.  Ready for review.
