### PR TITLE
updated the asset file to access its source via a cache object

### DIFF
--- a/lib/dassets/file_store.rb
+++ b/lib/dassets/file_store.rb
@@ -1,3 +1,5 @@
+require 'thread'
+
 module Dassets
 
   class FileStore
@@ -6,7 +8,7 @@ module Dassets
 
     def initialize(root)
       @root = RootPath.new(root)
-      @save_mutex = Mutex.new
+      @save_mutex = ::Mutex.new
     end
 
     def save(url, &block)

--- a/lib/dassets/server/request.rb
+++ b/lib/dassets/server/request.rb
@@ -17,7 +17,7 @@ class Dassets::Server
     # - then check if for a digested asset resource (kinda fast)
     # - then check if source exists for the digested asset (slower)
     def for_asset_file?
-      !!((get? || head?) && for_digested_asset? && asset_file.source_file.exists?)
+      !!((get? || head?) && for_digested_asset? && asset_file.source_cache.exists?)
     end
 
     def asset_path

--- a/lib/dassets/source_cache.rb
+++ b/lib/dassets/source_cache.rb
@@ -1,0 +1,33 @@
+require 'dassets/source_file'
+
+module Dassets; end
+class Dassets::SourceCache
+
+  attr_reader :digest_path, :source_file
+
+  def initialize(digest_path)
+    @digest_path = digest_path
+    @source_file = Dassets::SourceFile.find_by_digest_path(digest_path)
+  end
+
+  def content
+    @source_file.compiled
+  end
+
+  def fingerprint
+    @source_file.fingerprint
+  end
+
+  def key
+    "#{self.digest_path} -- #{self.mtime}"
+  end
+
+  def mtime
+    @source_file.mtime
+  end
+
+  def exists?
+    @source_file.exists?
+  end
+
+end

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
 require 'fileutils'
-require 'dassets/source_file'
 require 'dassets/file_store'
+require 'dassets/source_cache'
 require 'dassets/asset_file'
 
 class Dassets::AssetFile
@@ -13,19 +13,19 @@ class Dassets::AssetFile
     end
     subject{ @asset_file }
 
-    should have_readers :path, :dirname, :extname, :basename, :source_file
+    should have_readers :digest_path, :dirname, :extname, :basename, :source_cache
     should have_imeths  :digest!, :url, :fingerprint, :content
     should have_imeths  :href, :mtime, :size, :mime_type, :exists?, :==
 
     should "know its digest path, dirname, extname, and basename" do
-      assert_equal 'file1.txt', subject.path
+      assert_equal 'file1.txt', subject.digest_path
       assert_equal '.',     subject.dirname
       assert_equal '.txt',  subject.extname
       assert_equal 'file1', subject.basename
     end
 
-    should "use its source mtime as its mtime" do
-      assert_equal subject.source_file.mtime, subject.mtime
+    should "use its source file attrs as its own" do
+      assert_equal subject.source_cache.mtime, subject.mtime
       assert_equal Rack::Utils.bytesize(subject.content), subject.size
       assert_equal "text/plain", subject.mime_type
       assert subject.exists?
@@ -37,19 +37,19 @@ class Dassets::AssetFile
       assert_not null_file.exists?
     end
 
-    should "know its source file" do
-      assert_not_nil subject.source_file
-      assert_kind_of Dassets::SourceFile, subject.source_file
-      assert_equal subject.path, subject.source_file.digest_path
+    should "know its source cache" do
+      assert_not_nil subject.source_cache
+      assert_kind_of Dassets::SourceCache, subject.source_cache
+      assert_equal subject.digest_path, subject.source_cache.digest_path
     end
 
     should "have a fingerprint" do
       assert_not_nil subject.fingerprint
     end
 
-    should "get its fingerprint from its source file if none is given" do
+    should "get its fingerprint from its source cache if none is given" do
       af = Dassets::AssetFile.new('file1.txt')
-      assert_equal af.source_file.fingerprint, af.fingerprint
+      assert_equal af.source_cache.fingerprint, af.fingerprint
     end
 
     should "know it's content" do
@@ -59,7 +59,7 @@ class Dassets::AssetFile
       assert_nil null_file.content
     end
 
-    should "get its content from its source file if no output file" do
+    should "get its content from its source cache if no output file" do
       digest_path = 'nested/a-thing.txt.no-use'
       exp_content = "thing\n\nDUMB\nUSELESS"
 

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -19,15 +19,16 @@ module Dassets
       file = subject['nested/file3.txt']
 
       assert_kind_of Dassets::AssetFile, file
-      assert_equal 'nested/file3.txt', file.path
+      assert_equal 'nested/file3.txt', file.digest_path
       assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.fingerprint
     end
 
     should "return an asset file with unknown source if digest path not found" do
       file = subject['path/not/found.txt']
 
-      assert_kind_of Dassets::NullSourceFile, file.source_file
-      assert_not file.source_file.exists?
+      assert_kind_of Dassets::SourceCache, file.source_cache
+      assert_kind_of Dassets::NullSourceFile, file.source_cache.source_file
+      assert_not file.source_cache.exists?
     end
 
   end

--- a/test/unit/source_cache_tests.rb
+++ b/test/unit/source_cache_tests.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'dassets/source_file'
+require 'dassets/source_cache'
+
+class Dassets::SourceCache
+
+  class BaseTests < Assert::Context
+    desc "Dassets::SourceCache"
+    setup do
+      @source_cache = Dassets::SourceCache.new('file1.txt')
+    end
+    subject{ @source_cache }
+
+    test have_readers :digest_path, :source_file
+    should have_imeths :content, :fingerprint, :key, :mtime, :exists?
+
+    should "know its digest path" do
+      assert_equal 'file1.txt', subject.digest_path
+    end
+
+    should "know its source file" do
+      exp_source_file = Dassets::SourceFile.find_by_digest_path('file1.txt')
+      assert_equal exp_source_file, subject.source_file
+    end
+
+    should "exist if its source file exists" do
+      assert_equal subject.source_file.exists?, subject.exists?
+    end
+
+    should "use its source file's mtime as its mtime" do
+      assert_equal subject.source_file.mtime, subject.mtime
+    end
+
+    should "use its digest path and mtime as its key" do
+      exp_key = "#{subject.digest_path} -- #{subject.mtime}"
+      assert_equal exp_key, subject.key
+    end
+
+    should "get its fingerprint from the source file" do
+      assert_equal subject.source_file.fingerprint, subject.fingerprint
+    end
+
+    should "get its content from the source file" do
+      assert_equal subject.source_file.compiled, subject.content
+    end
+
+
+  end
+
+end


### PR DESCRIPTION
This is setting the stage for cacheing source by mtime.  This keeps
the asset file API the same but puts a cache between the asset file
and its source.  The cache key for source includes its mtime.  This
will allow you to cache source data that is expensive to compile
but have the cache expire if the source is updated.

In coming PRs, I will add the cache handler API and a basic in-memory
cache handler.  This will give a framework for developing custome
cache handlers that for things like redis, file, etc stores.

@jcredding ready for review.
