### PR TITLE
have the middleware response digest the asset file on success

### DIFF
--- a/lib/dassets/server/response.rb
+++ b/lib/dassets/server/response.rb
@@ -16,6 +16,7 @@ class Dassets::Server
       elsif !@asset_file.exists?
         [ 404, Rack::Utils::HeaderHash.new, ["Not Found"] ]
       else
+        @asset_file.digest!
         [ 200,
           Rack::Utils::HeaderHash.new.tap do |h|
             h["Content-Type"]   = @asset_file.mime_type.to_s

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -1,5 +1,6 @@
 require 'assert'
 require 'assert-rack-test'
+require 'fileutils'
 require 'test/support/app'
 require 'dassets/server'
 
@@ -33,6 +34,27 @@ module Dassets
       assert_equal 200, resp.status
       assert_equal Dassets['file2.txt'].size.to_s, resp.headers['Content-Length']
       assert_empty resp.body
+    end
+
+  end
+
+  class DigestTests < SuccessTests
+    setup do
+      Dassets.config.file_store = 'public'
+      @url = 'file1-daa05c683a4913b268653f7a7e36a5b4.txt'
+      @url_file = Dassets.config.file_store.store_path(@url)
+      FileUtils.rm(@url_file)
+    end
+    teardown do
+      Dassets.config.file_store = NullFileStore.new
+    end
+
+    should "digest the asset" do
+      assert_not_file_exists @url_file
+
+      resp = get "/#{@url}"
+      assert_equal 200, resp.status
+      assert_file_exists @url_file
     end
 
   end


### PR DESCRIPTION
This will write compiled output to the file store on success responses.

If you make your file store the public directory, you will essentially
"populate" it on the fly.  The first request hits the middelware
and write the file to the public dir.  Any subsequent requests just
get the file served from the public dir directly.

@jcredding ready for review.
