### PR TITLE
more forgiving Dassets initialization

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -19,7 +19,11 @@ module Dassets
   end
 
   def self.init
-    require self.config.assets_file
+    begin
+      require self.config.assets_file
+    rescue LoadError
+    end
+    raise 'no Dassets `root_path` specified' if !self.config.required_set?
   end
 
   def self.[](digest_path)

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -31,6 +31,15 @@ module Dassets
       assert_not file.source_cache.exists?
     end
 
+    should "complain if trying to init without setting the root path" do
+      orig_root = Dassets.config.root_path
+
+      Dassets.config.root_path = nil
+      assert_raises(RuntimeError){ Dassets.init }
+
+      Dassets.config.root_path = orig_root
+    end
+
   end
 
   class SourceListTests < BaseTests


### PR DESCRIPTION
Don't raise load errors on requiring the assets file - just quietly
move on as this may not be necessary in all scenarios.  Just raise
a more specific runtime error when missing required configs.

The goal here is to allow programmatic configuration of Dassets not
using the asset file.  This may be desired in certain init scenarios.

@jcredding ready for review.
