### PR TITLE
have the config know whether a digest path is a combo or not

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -44,7 +44,7 @@ module Dassets
     def initialize
       super
       @sources = []
-      @combinations = Hash.new{ |h,k| [k] } # digest pass-thru if none defined
+      @combinations = Hash.new{ |h, k| [k] } # digest pass-thru if none defined
       @cache = DefaultCache.new
     end
 
@@ -54,6 +54,12 @@ module Dassets
 
     def combination(key_digest_path, value_digest_paths)
       @combinations[key_digest_path.to_s] = [*value_digest_paths]
+    end
+
+    def combination?(key_digest_path)
+      # a digest path is only considered a combination is it is not the default
+      # pass-thru above
+      @combinations[key_digest_path.to_s] != [key_digest_path]
     end
   end
 

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -16,7 +16,7 @@ class Dassets::Config
     should have_options :file_store
 
     should have_reader :combinations
-    should have_imeth :source, :combination
+    should have_imeth :source, :combination, :combination?
 
     should "register new sources with the `source` method" do
       path = '/path/to/app/assets'
@@ -43,6 +43,13 @@ class Dassets::Config
       assert_equal ['test/digest.path'], subject.combinations['test/digest.path']
       subject.combination 'test/digest.path', ['some/other.path']
       assert_equal ['some/other.path'], subject.combinations['test/digest.path']
+    end
+
+    should "know which digest paths are actual combinations and which are just pass-thrus" do
+      subject.combination 'some/combination.path', ['some.path', 'another.path']
+
+      assert     subject.combination? 'some/combination.path'
+      assert_not subject.combination? 'some/non-combo.path'
     end
 
   end


### PR DESCRIPTION
This will be used in the upcoming recursive combinations feature.
I need to know if a given path is a combo or not to know if I need
to keep recursively processing the digest path or break the recursion
and treat it as a "null source".

@jcredding this is in prep for recursive combos - ready for review.
