### PR TITLE
cache asset file object on access

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -16,10 +16,11 @@ module Dassets
       require self.config.assets_file
     rescue LoadError
     end
+    @asset_files ||= {}
   end
 
   def self.[](digest_path)
-    AssetFile.new(digest_path)
+    @asset_files[digest_path] ||= AssetFile.new(digest_path)
   end
 
   def self.source_list

--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -21,39 +21,37 @@ class Dassets::AssetFile
   end
 
   def url
-    @url ||= begin
-      url_basename = "#{@basename}-#{self.fingerprint}#{@extname}"
-      File.join(@dirname, url_basename).sub(/^\.\//, '').sub(/^\//, '')
-    end
+    url_basename = "#{@basename}-#{self.fingerprint}#{@extname}"
+    File.join(@dirname, url_basename).sub(/^\.\//, '').sub(/^\//, '')
   end
 
   def href
-    @href ||= "/#{self.url}"
+    "/#{self.url}"
   end
 
   def fingerprint
     return nil if !self.exists?
-    @fingerprint ||= @source_proxy.fingerprint
+    @source_proxy.fingerprint
   end
 
   def content
     return nil if !self.exists?
-    @content ||= @source_proxy.content
+    @source_proxy.content
   end
 
   def mtime
     return nil if !self.exists?
-    @mtime ||= @source_proxy.mtime.httpdate
+    @source_proxy.mtime.httpdate
   end
 
   def size
     return nil if !self.exists?
-    @size ||= Rack::Utils.bytesize(self.content)
+    Rack::Utils.bytesize(self.content)
   end
 
   def mime_type
     return nil if !self.exists?
-    @mime_type ||= Rack::Mime.mime_type(@extname)
+    Rack::Mime.mime_type(@extname)
   end
 
   def exists?

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -82,6 +82,28 @@ class Dassets::AssetFile
       assert_equal "/nested/file1-.txt", nested.href
     end
 
+    should "not memoize its attributes" do
+      url1 = subject.url
+      url2 = subject.url
+      assert_not_same url2, url1
+
+      href1 = subject.href
+      href2 = subject.href
+      assert_not_same href2, href1
+
+      fingerprint1 = subject.fingerprint
+      fingerprint2 = subject.fingerprint
+      assert_not_same fingerprint2, fingerprint1
+
+      content1 = subject.content
+      content2 = subject.content
+      assert_not_same content2, content1
+
+      mtime1 = subject.mtime
+      mtime2 = subject.mtime
+      assert_not_same mtime2, mtime1
+    end
+
   end
 
   class DigestTests < UnitTests

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -25,6 +25,13 @@ module Dassets
       assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.fingerprint
     end
 
+    should "cache asset files" do
+      file1 = subject['nested/file3.txt']
+      file2 = subject['nested/file3.txt']
+
+      assert_same file2, file1
+    end
+
     should "return an asset file that doesn't exist if digest path not found" do
       file = subject['path/not/found.txt']
       assert_not file.exists?


### PR DESCRIPTION
Building asset files has become a non-trivial operation with the
addition of source proxies and combinations.  This changes the
`Dassets[]` method to cache the asset file objects so they don't
have to be rebuilt each time they are accessed.

This can provide a significant speed boost when using large/complex
combinations as an asset file may be accessed multiple times in any
given request (template rendering, middleware serving, etc).

@jcredding ready for review.
