### PR TITLE
cleanups to the existing test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dassets.configure do |c|
   # (optional) tell Dassets where to store digested asset files
   # if none given, Dassets will not write any digested output
   # use this to "cache" digested assets to the public dir (for example)
-  c.file_store '/path/to/public' # default: `NullFileStore.new`
+  c.file_store '/path/to/public' # default: `FileStore::NullStore.new`
 
 end
 ```

--- a/lib/dassets/config.rb
+++ b/lib/dassets/config.rb
@@ -10,7 +10,7 @@ module Dassets
     include NsOptions::Proxy
 
     option :assets_file,   Pathname,  :default => ENV['DASSETS_ASSETS_FILE']
-    option :file_store, FileStore, :default => proc{ NullFileStore.new }
+    option :file_store, FileStore, :default => proc{ FileStore::NullStore.new }
     option :cache, :default => proc{ Cache::NoCache.new }
 
     attr_reader :sources, :combinations

--- a/lib/dassets/file_store.rb
+++ b/lib/dassets/file_store.rb
@@ -1,35 +1,38 @@
 require 'thread'
 
-module Dassets; end
-class Dassets::FileStore
-  attr_reader :root
+module Dassets
 
-  def initialize(root)
-    @root = root
-    @save_mutex = ::Mutex.new
-  end
+  class FileStore
+    attr_reader :root
 
-  def save(url, &block)
-    @save_mutex.synchronize do
-      store_path(url).tap do |path|
-        FileUtils.mkdir_p(File.dirname(path))
-        File.open(path, "w"){ |f| f.write(block.call) }
+    def initialize(root)
+      @root = root
+      @save_mutex = ::Mutex.new
+    end
+
+    def save(url, &block)
+      @save_mutex.synchronize do
+        store_path(url).tap do |path|
+          FileUtils.mkdir_p(File.dirname(path))
+          File.open(path, "w"){ |f| f.write(block.call) }
+        end
       end
     end
+
+    def store_path(url)
+      File.join(@root, url)
+    end
+
+    class NullStore < FileStore
+      def initialize
+        super('')
+      end
+
+      def save(url, &block)
+        store_path(url) # no-op, just return the store path like the base does
+      end
+    end
+
   end
 
-  def store_path(url)
-    File.join(@root, url)
-  end
-
-end
-
-class Dassets::NullFileStore < Dassets::FileStore
-  def initialize
-    super('')
-  end
-
-  def save(url, &block)
-    store_path(url) # no-op, just return the store path like the base does
-  end
 end

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -1,8 +1,9 @@
 require 'assert'
+require 'dassets'
+
 require 'assert-rack-test'
 require 'fileutils'
 require 'test/support/app'
-require 'dassets/server'
 
 module Dassets
 
@@ -46,7 +47,7 @@ module Dassets
       FileUtils.rm(@url_file)
     end
     teardown do
-      Dassets.config.file_store = NullFileStore.new
+      Dassets.config.file_store = FileStore::NullStore.new
     end
 
     should "digest the asset" do

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -1,12 +1,13 @@
 require 'assert'
+require 'dassets/asset_file'
+
 require 'fileutils'
 require 'dassets/file_store'
 require 'dassets/source_proxy'
-require 'dassets/asset_file'
 
 class Dassets::AssetFile
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Dassets::AssetFile"
     setup do
       @asset_file = Dassets::AssetFile.new('file1.txt')
@@ -83,7 +84,7 @@ class Dassets::AssetFile
 
   end
 
-  class DigestTests < BaseTests
+  class DigestTests < UnitTests
     desc "being digested with an output path configured"
     setup do
       Dassets.config.file_store = TEST_SUPPORT_PATH.join('public').to_s
@@ -91,7 +92,7 @@ class Dassets::AssetFile
       @outfile = Dassets.config.file_store.store_path(@asset_file.url)
     end
     teardown do
-      Dassets.config.file_store = Dassets::NullFileStore.new
+      Dassets.config.file_store = Dassets::FileStore::NullStore.new
     end
 
     should "return the asset file url" do

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -23,7 +23,7 @@ class Dassets::Config
     should have_imeth :source, :combination, :combination?
 
     should "default the file store option to a null file store" do
-      assert_kind_of Dassets::NullFileStore, subject.file_store
+      assert_kind_of Dassets::FileStore::NullStore, subject.file_store
     end
 
     should "default the cache option to no caching" do

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
-require 'fileutils'
 require 'dassets'
+
+require 'fileutils'
+require 'dassets/asset_file'
 
 module Dassets
 

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -3,7 +3,7 @@ require 'dassets/engine'
 
 class Dassets::Engine
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "the base Dassets::Engine"
     setup do
       @engine = Dassets::Engine.new

--- a/test/unit/file_store_tests.rb
+++ b/test/unit/file_store_tests.rb
@@ -3,12 +3,47 @@ require 'dassets/file_store'
 
 class Dassets::FileStore
 
-  class NullTests < Assert::Context
-    desc "Dassets::NullFileStore"
-    subject{ Dassets::NullFileStore.new }
+  class UnitTests < Assert::Context
+    desc "Dassets::FileStore"
+    setup do
+      @root = TEST_SUPPORT_PATH.join('public')
+      @url = 'some/url'
+      @url_path = @root.join(@url).to_s
+      FileUtils.rm_f(@url_path)
 
-    should have_reader :root
+      @store = Dassets::FileStore.new(@root.to_s)
+    end
+    teardown do
+      FileUtils.rm_f(@url_path)
+    end
+    subject{ @store }
+
+    should have_readers :root
     should have_imeths :save, :store_path
+
+    should "know its root path" do
+      assert_equal @root.to_s, subject.root
+    end
+
+    should "build the store path based on a given url" do
+      assert_equal @url_path, subject.store_path(@url)
+    end
+
+    should "return write a file and return the store path on save" do
+      assert_not_file_exists @url_path
+      path = subject.save(@url){ 'some contents' }
+
+      assert_equal @url_path, path
+      assert_file_exists @url_path
+    end
+
+  end
+
+  class NullStoreTests < UnitTests
+    desc "NullStore"
+    setup do
+      @store = Dassets::FileStore::NullStore.new
+    end
 
     should "be a kind of FileStore" do
       assert_kind_of Dassets::FileStore, subject
@@ -18,12 +53,8 @@ class Dassets::FileStore
       assert_equal '', subject.root
     end
 
-    should "build the store path based on a given url" do
-      assert_equal '/some/url', subject.store_path('some/url')
-    end
-
     should "return the store path on save" do
-      assert_equal '/some/url', subject.save('some/url')
+      assert_equal "/#{@url}", subject.save(@url)
     end
 
   end

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -1,9 +1,11 @@
 require 'assert'
 require 'dassets/server/request'
 
+require 'dassets/asset_file'
+
 class Dassets::Server::Request
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Dassets::Server::Request"
     setup do
       @req = file_request('GET', '/file1-daa05c683a4913b268653f7a7e36a5b4.txt')

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -1,10 +1,12 @@
 require 'assert'
-require 'rack/utils'
 require 'dassets/server/response'
+
+require 'rack/utils'
+require 'dassets/asset_file'
 
 class Dassets::Server::Response
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Dassets::Server::Response"
     setup do
       @resp = file_response(Dassets::AssetFile.new(''))

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'dassets/source'
 
+require 'dassets/engine'
+
 class Dassets::Source
 
   class BaseTests < Assert::Context


### PR DESCRIPTION
This adds no new behavior.  These are cleanups to the test suite
to get it up to modern Assert testing style/standards.

In the process of cleaning up, I noticed the file store tests were
not very robust.  I updated the tests and in the process changed
the internal API for accessing a "null store" object.

Closes #60.

@jcredding ready for review.
