### PR TITLE
`base_url` config setting and handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"

--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.10"])
+  gem.add_development_dependency("assert", ["~> 2.12"])
   gem.add_development_dependency('assert-rack-test', ["~> 1.0"])
   gem.add_development_dependency("sinatra", ["~> 1.4"])
 

--- a/lib/dassets/config.rb
+++ b/lib/dassets/config.rb
@@ -20,6 +20,11 @@ module Dassets
       @combinations = Hash.new{ |h, k| [k] } # digest pass-thru if none defined
     end
 
+    def base_url(value = nil)
+      @base_url = value if !value.nil?
+      @base_url
+    end
+
     def source(path, &block)
       @sources << Source.new(path).tap{ |s| block.call(s) if block }
     end

--- a/lib/dassets/server/request.rb
+++ b/lib/dassets/server/request.rb
@@ -10,7 +10,14 @@ class Dassets::Server
     # the behavior to respect POST tunnel method specifiers. We always want
     # the real request method.
     def request_method; @env['REQUEST_METHOD']; end
-    def path_info;      @env['PATH_INFO'];      end
+
+    def path_info
+      @env['PATH_INFO'].sub(dassets_base_url, '')
+    end
+
+    def dassets_base_url
+      Dassets.config.base_url.to_s
+    end
 
     # Determine if the request is for an asset file
     # This will be called on every request so speed is an issue

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,6 +7,8 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
+require 'test/support/factory'
+
 require 'pathname'
 TEST_SUPPORT_PATH = Pathname.new(File.expand_path('../support', __FILE__))
 

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -17,8 +17,19 @@ class Dassets::Config
     subject{ @config }
 
     should have_options :file_store, :cache
-    should have_reader :combinations
-    should have_imeth :source, :combination, :combination?
+    should have_readers :combinations
+    should have_imeths :base_url, :source, :combination, :combination?
+
+    should "have no base url by default" do
+      assert_nil subject.base_url
+    end
+
+    should "set a base url" do
+      url = Factory.url
+      subject.base_url url
+
+      assert_equal url, subject.base_url
+    end
 
     should "default the file store option to a null file store" do
       assert_kind_of Dassets::FileStore::NullStore, subject.file_store

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -8,11 +8,21 @@ class Dassets::Server::Request
   class UnitTests < Assert::Context
     desc "Dassets::Server::Request"
     setup do
-      @req = file_request('GET', '/file1-daa05c683a4913b268653f7a7e36a5b4.txt')
+      @path = '/file1-daa05c683a4913b268653f7a7e36a5b4.txt'
+      @req = file_request('GET', @path)
     end
     subject{ @req }
 
+    should have_imeths :dassets_base_url
     should have_imeths :for_asset_file?, :asset_path, :asset_file
+
+    should "know its base url" do
+      assert_equal Dassets.config.base_url.to_s, subject.dassets_base_url
+    end
+
+    should "know its path info" do
+      assert_equal @path, subject.path_info
+    end
 
     should "know its asset_path" do
       assert_equal 'file1.txt', subject.asset_path
@@ -67,6 +77,28 @@ class Dassets::Server::Request
         'REQUEST_METHOD' => method,
         'PATH_INFO'      => path_info
       })
+    end
+
+  end
+
+  class BaseUrlTests < UnitTests
+    desc "when a base url is configured"
+    setup do
+      @orig_base_url = Dassets.config.base_url
+      @new_base_url = Factory.url
+      Dassets.config.base_url(@new_base_url)
+    end
+    teardown do
+      Dassets.config.base_url(@orig_base_url)
+    end
+
+    should "have the same base url as is configured" do
+      assert_equal @new_base_url.to_s, subject.dassets_base_url
+    end
+
+    should "remove the configured base url from the path info" do
+      assert_equal @path, file_request('GET', @path).path_info
+      assert_equal @path, file_request('GET', "#{@new_base_url}#{@path}").path_info
     end
 
   end


### PR DESCRIPTION
This adds a new config setting: `base_url`.  Use this to specify
that assets are hosted at a relative url root.  The server middleware
will look for this base url in the request path info and lookup
any assets relative to it.

Note: this also includes updating to the latest version of assert
and adding in a factory class to help with the testing.  This is
to keep up with our latest testing conventions.

@jcredding ready for review.
