### PR TITLE
auto init Dassets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ end
 ### Link To
 
 ```rb
-Dassets.init
 Dassets['css/site.css'].href       # => "/css/site-123abc.css"
 Dassets['img/logos/main.jpg'].href # => "/img/logos/main-a1b2c3.jpg"
 ```

--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -28,3 +28,5 @@ module Dassets
   end
 
 end
+
+Dassets.init

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -31,5 +31,3 @@ Dassets.configure do |c|
     s.engine 'useless', @useless_engine
   end
 end
-
-Dassets.init


### PR DESCRIPTION
Dassets requires an init step to set the asset files collection to
an empty hash.  This is to avoid a conditional in the index operator
method (`[]`).  Previously, the developer would have to remember to
call this method before using the index operator and if they forgot
Dassets would throw a nasty nil error.

This switches to just auto initializing Dassets on require.  There
is really no advantage to forcing a dev to do this and it just
results in confusion and errors if they don't.  This removes all
that aggrivation.

Closes #67.

@jcredding ready for review.