### PR TITLE
source proxy: cleanup tests; add tests for empty combos

### DIFF
--- a/lib/dassets/source_proxy.rb
+++ b/lib/dassets/source_proxy.rb
@@ -5,11 +5,11 @@ require 'dassets/source_file'
 module Dassets; end
 class Dassets::SourceProxy
 
-  attr_reader :digest_path, :source_files, :cache
+  attr_reader :digest_path, :cache, :source_files
 
   def initialize(digest_path, cache = nil)
     @digest_path  = digest_path
-    @cache = cache || Dassets::Cache::NoCache.new
+    @cache        = cache || Dassets::Cache::NoCache.new
     @source_files = get_source_files(@digest_path, @cache)
   end
 
@@ -26,7 +26,7 @@ class Dassets::SourceProxy
   end
 
   def mtime
-    @source_files.map{ |f| f.mtime }.max
+    @source_files.map{ |f| f.mtime }.compact.max
   end
 
   def exists?

--- a/test/unit/source_proxy_tests.rb
+++ b/test/unit/source_proxy_tests.rb
@@ -11,33 +11,33 @@ class Dassets::SourceProxy
   class UnitTests < Assert::Context
     desc "Dassets::SourceProxy"
     setup do
-      @source_proxy = Dassets::SourceProxy.new('file1.txt')
+      @source_proxy = Dassets::SourceProxy.new(Factory.string)
     end
     subject{ @source_proxy }
 
-    should have_readers :digest_path, :source_files, :cache
-    should have_imeths :content, :fingerprint, :key, :mtime, :exists?
+    should have_readers :digest_path, :cache, :source_files
+    should have_imeths :key, :content, :fingerprint, :mtime, :exists?
+
+  end
+
+  class NotComboTests < UnitTests
+    desc "when the digest path is not a combination"
+    setup do
+      @source_proxy = Dassets::SourceProxy.new('file1.txt')
+    end
 
     should "know its digest path" do
       assert_equal 'file1.txt', subject.digest_path
-    end
-
-    should "know its source files" do
-      exp_source_file = Dassets::SourceFile.find_by_digest_path('file1.txt')
-      assert_equal 1, subject.source_files.size
-      assert_equal exp_source_file, subject.source_files.first
     end
 
     should "use a `NoCache` cache handler by default" do
       assert_kind_of Dassets::Cache::NoCache, subject.cache
     end
 
-    should "exist if its source file exists" do
-      assert_equal subject.source_files.first.exists?, subject.exists?
-    end
-
-    should "use its source file's mtime as its mtime" do
-      assert_equal subject.source_files.first.mtime, subject.mtime
+    should "have a single source file" do
+      assert_equal 1, subject.source_files.size
+      exp_source_file = Dassets::SourceFile.find_by_digest_path('file1.txt')
+      assert_equal exp_source_file, subject.source_files.first
     end
 
     should "use its digest path and mtime as its key" do
@@ -45,53 +45,108 @@ class Dassets::SourceProxy
       assert_equal exp_key, subject.key
     end
 
-    should "get its fingerprint by MD5 hashing the compiled source" do
+    should "get its content from the compiled source of the single source file" do
+      assert_equal subject.source_files.first.compiled, subject.content
+    end
+
+    should "get its fingerprint by MD5 hashing the content" do
       exp_fp = Digest::MD5.new.hexdigest(subject.content)
       assert_equal exp_fp, subject.fingerprint
     end
 
-    should "get its content from the compiled source" do
-      assert_equal subject.source_files.first.compiled, subject.content
+    should "use its single source file's max mtime as its mtime" do
+      assert_equal subject.source_files.first.mtime, subject.mtime
+    end
+
+    should "exist if its single source file exists" do
+      assert_equal subject.source_files.first.exists?, subject.exists?
     end
 
   end
 
-  class CombinationTests < UnitTests
-    desc "when the digest path is a combination to multiple source files"
+  class ComboSetupTests < UnitTests
     setup do
       Dassets.config.combination 'file3.txt', ['file1.txt', 'file2.txt']
-      @source_proxy = Dassets::SourceProxy.new('file3.txt')
+      Dassets.config.combination 'file4.txt', []
+      Dassets.config.combination 'file5.txt', ['file3.txt', 'file4.txt']
+    end
+    teardown do
+      Dassets.config.combinations.delete('file5.txt')
+      Dassets.config.combinations.delete('file4.txt')
+      Dassets.config.combinations.delete('file3.txt')
+    end
+
+  end
+
+  class ComboTests < ComboSetupTests
+    desc "when the digest path is a combination to multiple source files"
+    setup do
       @exp_source_files = [
         Dassets::SourceFile.find_by_digest_path('file1.txt'),
         Dassets::SourceFile.find_by_digest_path('file2.txt')
       ]
-    end
-    teardown do
-      Dassets.config.combinations.delete('file3.txt')
+      @source_proxy = Dassets::SourceProxy.new('file3.txt')
     end
 
     should "know its digest path" do
       assert_equal 'file3.txt', subject.digest_path
     end
 
-    should "know its source file" do
+    should "know its source files" do
       assert_equal 2, subject.source_files.size
       assert_equal @exp_source_files, subject.source_files
     end
 
-    should "exist if its source file exists" do
-      exp_exists = @exp_source_files.inject(true){ |res, f| res && f.exists? }
-      assert_equal exp_exists, subject.exists?
+    should "get its content from the compiled source of its source files" do
+      exp_content = subject.source_files.map{ |f| f.compiled }.join("\n")
+      assert_equal exp_content, subject.content
     end
 
-    should "use its source file's mtime as its mtime" do
-      exp_mtime = @exp_source_files.map{ |f| f.mtime }.max
+    should "use its source files' max mtime as its mtime" do
+      exp_mtime = subject.source_files.map{ |f| f.mtime }.max
       assert_equal exp_mtime, subject.mtime
     end
 
-    should "get its content from the compiled source" do
-      exp_content = @exp_source_files.map{ |f| f.compiled }.join("\n")
-      assert_equal exp_content, subject.content
+    should "exist if its all its source files exist" do
+      exp_exists = subject.source_files.inject(true){ |res, f| res && f.exists? }
+      assert_equal exp_exists, subject.exists?
+    end
+
+  end
+
+  class EmptyComboTests < ComboSetupTests
+    desc "when the digest path is an empty combination"
+    setup do
+      @source_proxy = Dassets::SourceProxy.new('file4.txt')
+    end
+
+    should "not have any source files" do
+      assert_equal 0, subject.source_files.size
+    end
+
+    should "have empty content" do
+      assert_equal '', subject.content
+    end
+
+    should "have no mtime" do
+      assert_nil subject.mtime
+    end
+
+    should "exist" do
+      assert_true subject.exists?
+    end
+
+  end
+
+  class ComboWithEmptyComboTests < ComboSetupTests
+    desc "when the digest path is a combination that includes an empty combination"
+    setup do
+      @source_proxy = Dassets::SourceProxy.new('file5.txt')
+    end
+
+    should "ignore the mtime of the empty combination" do
+      exp_mtime = subject.source_files.map{ |f| f.mtime }.compact.max
+      assert_equal exp_mtime, subject.mtime
     end
 
   end


### PR DESCRIPTION
We discovered an edge-case type bug in how `mtime` was being calculated
on source proxies.  If you source proxy was for a combo that contained
an empty combo, `mtime` would error.  This is b/c the `mtime` of an
empty combo in `nil` so when your combo that contains the empty combo
tries to calculate its `mtime`, it ends up comparing `nil` to the
`mtime`s of its other source files which errors.

This fixes the issue by ignoring the `mtime` of emtpy combinations.
We do this by just compacting the `mtime` values array before selecting
the max value.

This also basically rewrites the source proxy tests.  There are a
number of small changes there:

* update tests to match implementation order
* break our separate contexts for the different scenarios being tested
* add contexts for specifically testing empty combos and combos composing
  empty combos (covers the error scenario above)
* update test descriptions to be more specific about what they are
  testing

@jcredding ready for review.