### PR TITLE
add config `set_base_url` method; use to cleanup test state

### DIFF
--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.12"])
+  gem.add_development_dependency("assert",           ["~> 2.15"])
   gem.add_development_dependency('assert-rack-test', ["~> 1.0"])
-  gem.add_development_dependency("sinatra", ["~> 1.4"])
-
+  gem.add_development_dependency("sinatra",          ["~> 1.4"])
 
   gem.add_dependency('ns-options', ["~> 1.1"])
   gem.add_dependency("rack",       ["~> 1.0"])

--- a/lib/dassets/config.rb
+++ b/lib/dassets/config.rb
@@ -21,8 +21,12 @@ module Dassets
     end
 
     def base_url(value = nil)
-      @base_url = value if !value.nil?
+      set_base_url(value) if !value.nil?
       @base_url
+    end
+
+    def set_base_url(value)
+      @base_url = value
     end
 
     def source(path, &block)

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -18,17 +18,29 @@ class Dassets::Config
 
     should have_options :file_store, :cache
     should have_readers :combinations
-    should have_imeths :base_url, :source, :combination, :combination?
+    should have_imeths :base_url, :set_base_url
+    should have_imeths :source, :combination, :combination?
 
     should "have no base url by default" do
       assert_nil subject.base_url
     end
 
-    should "set a base url" do
+    should "set non-nil base urls" do
       url = Factory.url
       subject.base_url url
-
       assert_equal url, subject.base_url
+
+      subject.base_url(nil)
+      assert_equal url, subject.base_url
+    end
+
+    should "force set any base urls" do
+      url = Factory.url
+      subject.set_base_url url
+      assert_equal url, subject.base_url
+
+      subject.set_base_url(nil)
+      assert_nil subject.base_url
     end
 
     should "default the file store option to a null file store" do

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -85,11 +85,11 @@ class Dassets::Server::Request
     desc "when a base url is configured"
     setup do
       @orig_base_url = Dassets.config.base_url
-      @new_base_url = Factory.url
+      @new_base_url  = Factory.url
       Dassets.config.base_url(@new_base_url)
     end
     teardown do
-      Dassets.config.base_url(@orig_base_url)
+      Dassets.config.set_base_url(@orig_base_url)
     end
 
     should "have the same base url as is configured" do


### PR DESCRIPTION
This fixes an issue where modified base url state was being set
in the request tests but not being properly reset.  This issue is
that the `base_url` method won't change the base url if given a nil
value.  The requests tests were resetting the base url to the orig
value but the orig value was nil so the reset had no effect.

This updates the config api to have a `set_base_url` method that
sets *any* given value.  The `base_url` method uses this method
to set its values and the request test now use this method to
force reset the base url, ensuring clean state.

This was noticed when I went to update the asset file's `href`
method to honor any configured base url.

@jcredding ready for review.