### PR TITLE
update AssetFile#url to honor any configured `base_url`

### DIFF
--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -17,17 +17,19 @@ class Dassets::AssetFile
 
   def digest!
     return if !self.exists?
-    Dassets.config.file_store.save(self.url){ self.content }
+    Dassets.config.file_store.save(self.path){ self.content }
+  end
+
+  def path
+    path_basename = "#{@basename}-#{self.fingerprint}#{@extname}"
+    File.join(@dirname, path_basename).sub(/^\.\//, '').sub(/^\//, '')
   end
 
   def url
-    url_basename = "#{@basename}-#{self.fingerprint}#{@extname}"
-    File.join(@dirname, url_basename).sub(/^\.\//, '').sub(/^\//, '')
+    "#{dassets_base_url}/#{self.path}"
   end
 
-  def href
-    "/#{self.url}"
-  end
+  alias_method :href, :url
 
   def fingerprint
     return nil if !self.exists?
@@ -62,6 +64,12 @@ class Dassets::AssetFile
     other_asset_file.kind_of?(Dassets::AssetFile) &&
     self.digest_path == other_asset_file.digest_path &&
     self.fingerprint == other_asset_file.fingerprint
+  end
+
+  private
+
+  def dassets_base_url
+    Dassets.config.base_url.to_s
   end
 
 end


### PR DESCRIPTION
Since the base url will be honored (and needed) when hosting asset
files, don't make the user manually add it to asset urls.  Instead
have the base url be auto-included when generating asset file urls.

Note: in addition, I've renamed the old `url` method to `path` as
this name more accurately describes the intent of the method: that
this is the path relative to the asset root for this asset.  This
value is also used to cache the assets contents to the file store
(which is confusing if the method is named `url`).  The new `url`
method is more accurately a "url", honoring the base url as needed.
I've aliased `href` to `url` for backwards compatibility.

@jcredding ready for review.