### PR TITLE
server response: handle partial content requests; send body in chunks

### DIFF
--- a/lib/dassets/server/response.rb
+++ b/lib/dassets/server/response.rb
@@ -6,6 +6,7 @@ module Dassets; end
 class Dassets::Server
 
   class Response
+
     attr_reader :asset_file, :status, :headers, :body
 
     def initialize(env, asset_file)
@@ -13,24 +14,88 @@ class Dassets::Server
 
       mtime = @asset_file.mtime.to_s
       @status, @headers, @body = if env['HTTP_IF_MODIFIED_SINCE'] == mtime
-        [ 304, Rack::Utils::HeaderHash.new, [] ]
+        [ 304, Rack::Utils::HeaderHash.new('Last-Modified' => mtime), [] ]
       elsif !@asset_file.exists?
         [ 404, Rack::Utils::HeaderHash.new, ["Not Found"] ]
       else
         @asset_file.digest!
-        [ 200,
+        body = Body.new(env, @asset_file)
+        [ body.partial? ? 206 : 200,
           Rack::Utils::HeaderHash.new.tap do |h|
-            h["Content-Type"]   = @asset_file.mime_type.to_s
-            h["Content-Length"] = @asset_file.size.to_s
-            h["Last-Modified"]  = mtime
+            h['Last-Modified']  = mtime
+            h['Content-Type']   = @asset_file.mime_type.to_s
+            h['Content-Length'] = body.size.to_s
+            h['Content-Range']  = body.content_range if body.partial?
           end,
-          env["REQUEST_METHOD"] == "HEAD" ? [] : [ @asset_file.content ]
+          env["REQUEST_METHOD"] == "HEAD" ? [] : body
         ]
       end
     end
 
     def to_rack
       [@status, @headers.to_hash, @body]
+    end
+
+    class Body
+
+      # this class borrows from the body range handling in Rack::File and adapts
+      # it for use with Dasset's asset files and their generic string content.
+
+      CHUNK_SIZE = (8*1024).freeze # 8k
+
+      attr_reader :asset_file, :size, :content_range
+
+      def initialize(env, asset_file)
+        @asset_file = asset_file
+
+        content_size = @asset_file.size
+        ranges = Rack::Utils.byte_ranges(env, content_size)
+        if ranges.nil? || ranges.empty? || ranges.length > 1
+          # No ranges or multiple ranges are not supported
+          @range         = 0..content_size-1
+          @content_range = nil
+        else
+          # single range
+          @range         = ranges[0]
+          @content_range = "bytes #{@range.begin}-#{@range.end}/#{content_size}"
+        end
+
+        @size = self.range_end - self.range_begin + 1
+      end
+
+      def partial?
+        !@content_range.nil?
+      end
+
+      def range_begin; @range.begin; end
+      def range_end;   @range.end;   end
+
+      def each
+        StringIO.open(@asset_file.content, "rb") do |io|
+          io.seek(@range.begin)
+          remaining_len = self.size
+          while remaining_len > 0
+            part = io.read([CHUNK_SIZE, remaining_len].min)
+            break if part.nil?
+
+            remaining_len -= part.length
+            yield part
+          end
+        end
+      end
+
+      def inspect
+        "#<#{self.class}:#{'0x0%x' % (self.object_id << 1)} " \
+          "digest_path=#{self.asset_file.digest_path} " \
+          "range_begin=#{self.range_begin} range_end=#{self.range_end}>"
+      end
+
+      def ==(other_body)
+        self.asset_file  == other_body.asset_file  &&
+        self.range_begin == other_body.range_begin &&
+        self.range_end   == other_body.range_end
+      end
+
     end
 
   end

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -9,61 +9,220 @@ class Dassets::Server::Response
   class UnitTests < Assert::Context
     desc "Dassets::Server::Response"
     setup do
-      @resp = file_response(Dassets::AssetFile.new(''))
+      @env        = {}
+      @asset_file = Dassets['file1.txt']
+
+      @response = Dassets::Server::Response.new(@env, @asset_file)
     end
-    subject{ @resp }
+    subject{ @response }
 
     should have_readers :asset_file, :status, :headers, :body
     should have_imeths :to_rack
 
     should "handle not modified files" do
-      af = Dassets['file1.txt']
-      resp = file_response(af, 'HTTP_IF_MODIFIED_SINCE' => af.mtime)
+      env = { 'HTTP_IF_MODIFIED_SINCE' => @asset_file.mtime }
+      resp = Dassets::Server::Response.new(env, @asset_file)
 
       assert_equal 304, resp.status
-      assert_equal [], resp.body
-      assert_equal Rack::Utils::HeaderHash.new, resp.headers
-      assert_equal [ 304, {}, [] ], resp.to_rack
+      assert_equal [],  resp.body
+
+      exp_headers = Rack::Utils::HeaderHash.new('Last-Modified' => @asset_file.mtime.to_s)
+      assert_equal exp_headers, resp.headers
+
+      assert_equal [304, exp_headers.to_hash, []], resp.to_rack
     end
 
     should "handle found files" do
-      af = Dassets['file1.txt']
-      resp = file_response(af)
-      exp_headers = {
-        'Content-Type'   => 'text/plain',
-        'Content-Length' => Rack::Utils.bytesize(af.content).to_s,
-        'Last-Modified'  => af.mtime.to_s
-      }
+      resp = Dassets::Server::Response.new(@env, @asset_file)
 
       assert_equal 200, resp.status
-      assert_equal [ af.content ], resp.body
+
+      exp_body = Body.new(@env, @asset_file)
+      assert_equal exp_body, resp.body
+
+      exp_headers = {
+        'Content-Type'   => 'text/plain',
+        'Content-Length' => Rack::Utils.bytesize(@asset_file.content).to_s,
+        'Last-Modified'  => @asset_file.mtime.to_s
+      }
       assert_equal exp_headers, resp.headers
-      assert_equal [ 200, exp_headers, [ af.content ] ], resp.to_rack
+
+      assert_equal [200, exp_headers, exp_body], resp.to_rack
     end
 
     should "have an empty body for found files with a HEAD request" do
-      af = Dassets['file1.txt']
-      resp = file_response(af, 'REQUEST_METHOD' => 'HEAD')
+      env = { 'REQUEST_METHOD' => 'HEAD' }
+      resp = Dassets::Server::Response.new(env, @asset_file)
 
       assert_equal 200, resp.status
       assert_equal [], resp.body
     end
 
     should "handle not found files" do
-      af = Dassets['not-found-file.txt']
-      resp = file_response(af)
+      af   = Dassets['not-found-file.txt']
+      resp = Dassets::Server::Response.new(@env, af)
 
-      assert_equal 404, resp.status
-      assert_equal ['Not Found'], resp.body
+      assert_equal 404,                         resp.status
+      assert_equal ['Not Found'],               resp.body
       assert_equal Rack::Utils::HeaderHash.new, resp.headers
-      assert_equal [ 404, {}, ['Not Found'] ], resp.to_rack
+      assert_equal [404, {}, ['Not Found']],    resp.to_rack
     end
 
-    protected
+  end
 
-    def file_response(asset_file, env={})
-      require 'dassets/server/response'
-      Dassets::Server::Response.new(env, asset_file)
+  class PartialContentTests < UnitTests
+    desc "for a partial content request"
+    setup do
+      @body = Body.new(@env, @asset_file)
+      Assert.stub(Body, :new).with(@env, @asset_file){ @body }
+
+      content_range = Factory.string
+      Assert.stub(@body, :content_range){ content_range }
+      Assert.stub(@body, :partial?){ true }
+
+      @response = Dassets::Server::Response.new(@env, @asset_file)
+    end
+
+    should "be a partial content response" do
+      assert_equal 206, subject.status
+
+      assert_includes 'Content-Range', subject.headers
+      assert_equal @body.content_range, subject.headers['Content-Range']
+    end
+
+  end
+
+  class BodyTests < UnitTests
+    desc "Body"
+    setup do
+      @body = Body.new(@env, @asset_file)
+    end
+    subject{ @body }
+
+    should have_readers :asset_file, :size, :content_range
+    should have_imeths :partial?, :range_begin, :range_end
+    should have_imeths :each
+
+    should "know its chunk size" do
+      assert_equal 8192, Body::CHUNK_SIZE
+    end
+
+    should "know its asset file" do
+      assert_equal @asset_file, subject.asset_file
+    end
+
+    should "know if it is equal to another body" do
+      same_af_same_range = Body.new(@env, @asset_file)
+      Assert.stub(same_af_same_range, :range_begin){ subject.range_begin }
+      Assert.stub(same_af_same_range, :range_end){ subject.range_end }
+      assert_equal same_af_same_range, subject
+
+      other_af_same_range = Body.new(@env, Dassets['file2.txt'])
+      Assert.stub(other_af_same_range, :range_begin){ subject.range_begin }
+      Assert.stub(other_af_same_range, :range_end){ subject.range_end }
+      assert_not_equal other_af_same_range, subject
+
+      same_af_other_range = Body.new(@env, @asset_file)
+
+      Assert.stub(same_af_other_range, :range_begin){ Factory.integer }
+      Assert.stub(same_af_other_range, :range_end){ subject.range_end }
+      assert_not_equal same_af_other_range, subject
+
+      Assert.stub(same_af_other_range, :range_begin){ subject.range_begin }
+      Assert.stub(same_af_other_range, :range_end){ Factory.integer }
+      assert_not_equal same_af_other_range, subject
+    end
+
+  end
+
+  class BodyIOTests < BodyTests
+    setup do
+      @min_num_chunks = 3
+      @num_chunks     = @min_num_chunks + Factory.integer(3)
+
+      content = 'a' * (@num_chunks * Body::CHUNK_SIZE)
+      Assert.stub(@asset_file, :content){ content }
+    end
+
+  end
+
+  class NonPartialBodyTests < BodyIOTests
+    desc "for non/multi/invalid partial content requests"
+    setup do
+      range = [nil, 'bytes=', 'bytes=0-1,2-3', 'bytes=3-2', 'bytes=abc'].choice
+      env = range.nil? ? {} : { 'HTTP_RANGE' => range }
+      @body = Body.new(env, @asset_file)
+    end
+
+    should "not be partial" do
+      assert_false subject.partial?
+    end
+
+    should "be the full content size" do
+      assert_equal @asset_file.size, subject.size
+    end
+
+    should "have no content range" do
+      assert_nil subject.content_range
+    end
+
+    should "have the full content size as its range" do
+      assert_equal 0,              subject.range_begin
+      assert_equal subject.size-1, subject.range_end
+    end
+
+    should "chunk the full content when iterated" do
+      chunks = []
+      subject.each{ |chunk| chunks << chunk }
+
+      assert_equal @num_chunks,               chunks.size
+      assert_equal subject.class::CHUNK_SIZE, chunks.first.size
+      assert_equal @asset_file.content,       chunks.join('')
+    end
+
+  end
+
+  class PartialBodyTests < BodyIOTests
+    desc "for a partial content request"
+    setup do
+      @start_chunk    = Factory.boolean ? 0 : 1
+      @partial_begin  = @start_chunk * Body::CHUNK_SIZE
+      @partial_chunks = @num_chunks - Factory.integer(@min_num_chunks)
+      @partial_size   = @partial_chunks * Body::CHUNK_SIZE
+      @partial_end    = @partial_begin + (@partial_size-1)
+
+      env = { 'HTTP_RANGE' => "bytes=#{@partial_begin}-#{@partial_end}" }
+      @body = Body.new(env, @asset_file)
+    end
+    subject{ @body }
+
+    should "be partial" do
+      assert_true subject.partial?
+    end
+
+    should "be the specified partial size" do
+      assert_equal @partial_size, subject.size
+    end
+
+    should "know its content range" do
+      exp = "bytes #{@partial_begin}-#{@partial_end}/#{@asset_file.size}"
+      assert_equal exp, subject.content_range
+    end
+
+    should "have the know its range" do
+      assert_equal @partial_begin, subject.range_begin
+      assert_equal @partial_end,   subject.range_end
+    end
+
+    should "chunk the range when iterated" do
+      chunks = []
+      subject.each{ |chunk| chunks << chunk }
+
+      assert_equal @partial_chunks,           chunks.size
+      assert_equal subject.class::CHUNK_SIZE, chunks.first.size
+
+      exp = @asset_file.content[@partial_begin..@partial_end]
+      assert_equal exp, chunks.join('')
     end
 
   end


### PR DESCRIPTION
This updates the server middle ware to more properly handle requests.
First, this adds support for partial content requests.  The response
will build its body honoring any single, valid range request headers.
Second, this switches to iterating over the body content in 8k chunks.
This is consistent with the implementation used by `Rack::File`.

Note too: this also adds the `Last-Modified` header to not modified
responses.  This should have been done originally but was missed.

All of this logic is adapted from `Rack::File`'s logic but adapted
to work with asset files.

@jcredding ready for review.  FYI, I'll use this as a basis for doing similar things in deas' coming `send_file` helper.  I'll be doing that as part of the effort to remove sinatra from deas.