### PR TITLE
Update asset file to write to the file store using its url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'rake' "~> 10.4.0"
-gem 'pry', "~> 0.9.0"
+gem 'rake', "~> 10.4.0"
+gem 'pry',  "~> 0.9.0"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Dassets.configure do |c|
 
   # (optional) tell Dassets where to store digested asset files
   # if none given, Dassets will not write any digested output
-  # use this to "cache" digested assets to the public dir (for example)
+  # use this to "cache" digested assets to the public dir so that
+  # your web server can serve them directly
   c.file_store '/path/to/public' # default: `FileStore::NullStore.new`
 
 end

--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -17,16 +17,13 @@ class Dassets::AssetFile
 
   def digest!
     return if !self.exists?
-    Dassets.config.file_store.save(self.path){ self.content }
-  end
-
-  def path
-    path_basename = "#{@basename}-#{self.fingerprint}#{@extname}"
-    File.join(@dirname, path_basename).sub(/^\.\//, '').sub(/^\//, '')
+    Dassets.config.file_store.save(self.url){ self.content }
   end
 
   def url
-    "#{dassets_base_url}/#{self.path}"
+    path_basename = "#{@basename}-#{self.fingerprint}#{@extname}"
+    path = File.join(@dirname, path_basename).sub(/^\.\//, '').sub(/^\//, '')
+    "#{dassets_base_url}/#{path}"
   end
 
   alias_method :href, :url

--- a/lib/dassets/server/request.rb
+++ b/lib/dassets/server/request.rb
@@ -1,4 +1,4 @@
-require 'rack/request'
+require 'rack'
 
 module Dassets; end
 class Dassets::Server

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,8 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.base_url
+    Factory.boolean ? Factory.url : nil
+  end
+
 end

--- a/test/support/public/file1-daa05c683a4913b268653f7a7e36a5b4.txt
+++ b/test/support/public/file1-daa05c683a4913b268653f7a7e36a5b4.txt
@@ -1,1 +1,0 @@
-file1.txt

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -81,19 +81,21 @@ module Dassets
 
   class DigestTests < SuccessTests
     setup do
+      base_url = Factory.base_url
+      Assert.stub(Dassets.config, :base_url){ base_url }
       Dassets.config.file_store = TEST_SUPPORT_PATH.join('public').to_s
-      @url = 'file1-daa05c683a4913b268653f7a7e36a5b4.txt'
+      @url = Dassets['file1.txt'].url
       @url_file = Dassets.config.file_store.store_path(@url)
-      FileUtils.rm(@url_file)
     end
     teardown do
+      FileUtils.rm(@url_file)
       Dassets.config.file_store = FileStore::NullStore.new
     end
 
     should "digest the asset" do
       assert_not_file_exists @url_file
 
-      resp = get "/#{@url}"
+      resp = get @url
       assert_equal 200, resp.status
       assert_file_exists @url_file
     end


### PR DESCRIPTION
This updates the asset file to write to the file store using its
url. The goal here is to make sure the base url is used when
writing to the file store. Previously, the asset files were being
written without the base url. This caused HTTP servers to not be
able to directly serve the files because the url (which included
the base url) didn't match the path where the files were stored.

Now that the path method is no longer being used, its being merged
into the url method. This is to avoid any future confusion over
using the url method with the file store and not the path method.
Related to this, the readme has also been updated to better explain
how the file store should be configured. Its intended to be
configured with the public dir so HTTP servers can serve files out
of it.

This also updates the test suite to add additional testing using
the base url. The digest system and unit tests now will randomly
have a base url. This ensure digesting works with or without a
base url being configured. Because of this, the digested file1
support file can't be checked in. Without a base url the tests
would always generate the same digested file1 but now that a base
url may be used they won't. The tests now remove the files they
generate which means they will also remove the checked in version.

This also fixes a require issue with the server request and a
Gemfile typo. Requiring `rack/request` for some reason didn't
define the `Rack::Request::GET` constant and the server request
unit tests would fail.

@kellyredding - Ready for review.