### PR TITLE
Allow configuring a content and fingerprint cache separately

### DIFF
--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -12,7 +12,10 @@ class Dassets::AssetFile
     @dirname  = File.dirname(@digest_path)
     @extname  = File.extname(@digest_path)
     @basename = File.basename(@digest_path, @extname)
-    @source_proxy = Dassets::SourceProxy.new(@digest_path, Dassets.config.cache)
+    @source_proxy = Dassets::SourceProxy.new(@digest_path, {
+      :content_cache     => Dassets.config.content_cache,
+      :fingerprint_cache => Dassets.config.fingerprint_cache
+    })
   end
 
   def digest!

--- a/lib/dassets/cache.rb
+++ b/lib/dassets/cache.rb
@@ -4,7 +4,7 @@ module Dassets::Cache
   class MemCache
     require 'thread'
 
-    # this is a thread-safe in-memory cache for use with the `SourceCache`
+    # this is a thread-safe in-memory cache
 
     def initialize
       @hash = {}

--- a/lib/dassets/config.rb
+++ b/lib/dassets/config.rb
@@ -10,14 +10,15 @@ module Dassets
     include NsOptions::Proxy
 
     option :file_store, FileStore, :default => proc{ FileStore::NullStore.new }
-    option :cache, :default => proc{ Cache::NoCache.new }
 
     attr_reader :sources, :combinations
 
     def initialize
       super
-      @sources = []
-      @combinations = Hash.new{ |h, k| [k] } # digest pass-thru if none defined
+      @sources           = []
+      @combinations      = Hash.new{ |h, k| [k] } # digest pass-thru if none defined
+      @content_cache     = Dassets::Cache::NoCache.new
+      @fingerprint_cache = Dassets::Cache::NoCache.new
     end
 
     def base_url(value = nil)
@@ -27,6 +28,16 @@ module Dassets
 
     def set_base_url(value)
       @base_url = value
+    end
+
+    def content_cache(cache = nil)
+      @content_cache = cache if !cache.nil?
+      @content_cache
+    end
+
+    def fingerprint_cache(cache = nil)
+      @fingerprint_cache = cache if !cache.nil?
+      @fingerprint_cache
     end
 
     def source(path, &block)

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -7,13 +7,13 @@ module Dassets
 
   class SourceFile
 
-    def self.find_by_digest_path(path, cache = nil)
+    def self.find_by_digest_path(path, options = nil)
       # look in the configured source list
       source_files = Dassets.source_list.map{ |p| self.new(p) }
 
       # get the last matching one (in case two source files have the same digest
       # path the last one *should* be correct since it was last to be configured)
-      source_files.select{ |s| s.digest_path == path }.last || NullSourceFile.new(path, cache)
+      source_files.select{ |s| s.digest_path == path }.last || NullSourceFile.new(path, options)
     end
 
     attr_reader :file_path
@@ -86,11 +86,11 @@ module Dassets
 
   class NullSourceFile < SourceFile
 
-    def initialize(digest_path, cache = nil)
+    def initialize(digest_path, options = nil)
       @file_path, @ext_list = '', []
       @digest_path = digest_path
       @source_proxy = if Dassets.config.combination?(@digest_path)
-        SourceProxy.new(@digest_path, cache)
+        SourceProxy.new(@digest_path, options)
       else
         NullSourceProxy.new
       end

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -39,9 +39,12 @@ class Dassets::AssetFile
     end
 
     should "know its source proxy" do
-      assert_not_nil subject.source_proxy
-      assert_kind_of Dassets::SourceProxy, subject.source_proxy
-      assert_equal subject.digest_path, subject.source_proxy.digest_path
+      source_proxy = subject.source_proxy
+      assert_not_nil source_proxy
+      assert_kind_of Dassets::SourceProxy, source_proxy
+      assert_equal subject.digest_path, source_proxy.digest_path
+      assert_equal Dassets.config.content_cache, source_proxy.content_cache
+      assert_equal Dassets.config.fingerprint_cache, source_proxy.fingerprint_cache
     end
 
     should "have a fingerprint" do

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -16,9 +16,10 @@ class Dassets::Config
     end
     subject{ @config }
 
-    should have_options :file_store, :cache
+    should have_options :file_store
     should have_readers :combinations
     should have_imeths :base_url, :set_base_url
+    should have_imeths :content_cache, :fingerprint_cache
     should have_imeths :source, :combination, :combination?
 
     should "have no base url by default" do
@@ -47,8 +48,30 @@ class Dassets::Config
       assert_kind_of Dassets::FileStore::NullStore, subject.file_store
     end
 
-    should "default the cache option to no caching" do
-      assert_kind_of Dassets::Cache::NoCache, subject.cache
+    should "default its content cache" do
+      assert_instance_of Dassets::Cache::NoCache, subject.content_cache
+    end
+
+    should "allow configuring non-nil content caches" do
+      cache = Dassets::Cache::MemCache.new
+      subject.content_cache(cache)
+      assert_equal cache, subject.content_cache
+
+      subject.content_cache(nil)
+      assert_equal cache, subject.content_cache
+    end
+
+    should "default its fingerprint cache" do
+      assert_instance_of Dassets::Cache::NoCache, subject.fingerprint_cache
+    end
+
+    should "allow configuring non-nil fingerprint caches" do
+      cache = Dassets::Cache::MemCache.new
+      subject.fingerprint_cache(cache)
+      assert_equal cache, subject.fingerprint_cache
+
+      subject.fingerprint_cache(nil)
+      assert_equal cache, subject.fingerprint_cache
     end
 
     should "register new sources with the `source` method" do

--- a/test/unit/source_proxy_tests.rb
+++ b/test/unit/source_proxy_tests.rb
@@ -15,7 +15,8 @@ class Dassets::SourceProxy
     end
     subject{ @source_proxy }
 
-    should have_readers :digest_path, :cache, :source_files
+    should have_readers :digest_path, :content_cache, :fingerprint_cache
+    should have_readers :source_files
     should have_imeths :key, :content, :fingerprint, :mtime, :exists?
 
   end
@@ -30,8 +31,9 @@ class Dassets::SourceProxy
       assert_equal 'file1.txt', subject.digest_path
     end
 
-    should "use a `NoCache` cache handler by default" do
-      assert_kind_of Dassets::Cache::NoCache, subject.cache
+    should "use no cache by default" do
+      assert_kind_of Dassets::Cache::NoCache, subject.content_cache
+      assert_kind_of Dassets::Cache::NoCache, subject.fingerprint_cache
     end
 
     should "have a single source file" do
@@ -155,7 +157,10 @@ class Dassets::SourceProxy
     desc "with a `NoCache` cache handler"
     setup do
       @cache = Dassets::Cache::NoCache.new
-      @source_proxy = Dassets::SourceProxy.new('file1.txt', @cache)
+      @source_proxy = Dassets::SourceProxy.new('file1.txt', {
+        :content_cache     => @cache,
+        :fingerprint_cache => @cache
+      })
     end
 
     should "not cache its source content/fingerprint" do
@@ -173,8 +178,12 @@ class Dassets::SourceProxy
   class MemCacheTests < UnitTests
     desc "with a `MemCache` cache handler"
     setup do
-      @cache = Dassets::Cache::MemCache.new
-      @source_proxy = Dassets::SourceProxy.new('file1.txt', @cache)
+      @content_cache     = Dassets::Cache::MemCache.new
+      @fingerprint_cache = Dassets::Cache::MemCache.new
+      @source_proxy = Dassets::SourceProxy.new('file1.txt', {
+        :content_cache     => @content_cache,
+        :fingerprint_cache => @fingerprint_cache
+      })
     end
 
     should "cache its source content/fingerprint in memory" do


### PR DESCRIPTION
This changes the cache options to allow configuring a separate
content and fingerprint cache. This allows configuring no-cache
for the content (so file contents aren't stored in memory) but
using a mem-cache for fingerprints. This is useful when using
Dassets in a production environment when the assets are cached to
a public directory. The assets content doesn't need to be cached
because an HTTP server can serve them directly but the fingerprints
are cached so asset urls can still be generated quickly.

The config now has a separate option for content caching and
fingerprint caching. These are automatically passed to an asset
files source proxy just like the previous single cache was. The
fingerprint cache is only used to store fingerprints and the
content cache is only used to store file contents.

@kellyredding - Ready for review.