### PR TITLE
allow configuring response header values on a per-source basis

### DIFF
--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -56,6 +56,10 @@ class Dassets::AssetFile
     Rack::Mime.mime_type(@extname)
   end
 
+  def response_headers
+    @source_proxy.response_headers
+  end
+
   def exists?
     @source_proxy.exists?
   end

--- a/lib/dassets/server/response.rb
+++ b/lib/dassets/server/response.rb
@@ -21,7 +21,7 @@ class Dassets::Server
         @asset_file.digest!
         body = Body.new(env, @asset_file)
         [ body.partial? ? 206 : 200,
-          Rack::Utils::HeaderHash.new.tap do |h|
+          Rack::Utils::HeaderHash.new.merge(@asset_file.response_headers).tap do |h|
             h['Last-Modified']  = mtime
             h['Content-Type']   = @asset_file.mime_type.to_s
             h['Content-Length'] = body.size.to_s

--- a/lib/dassets/source.rb
+++ b/lib/dassets/source.rb
@@ -3,12 +3,13 @@ require 'dassets/engine'
 module Dassets; end
 class Dassets::Source
 
-  attr_reader :path, :engines
+  attr_reader :path, :engines, :response_headers
 
   def initialize(path)
     @path = path.to_s
     @filter = proc{ |paths| paths }
     @engines = Hash.new{ |h,k| Dassets::NullEngine.new }
+    @response_headers = Hash.new
   end
 
   def filter(&block)

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -60,6 +60,10 @@ module Dassets
       File.mtime(@file_path)
     end
 
+    def response_headers
+      self.source.nil? ? Hash.new : self.source.response_headers
+    end
+
     def ==(other_source_file)
       self.file_path == other_source_file.file_path
     end

--- a/lib/dassets/source_proxy.rb
+++ b/lib/dassets/source_proxy.rb
@@ -35,6 +35,10 @@ class Dassets::SourceProxy
     @source_files.map{ |f| f.mtime }.compact.max
   end
 
+  def response_headers
+    @source_files.inject(Hash.new){ |hash, f| hash.merge!(f.response_headers) }
+  end
+
   def exists?
     @source_files.inject(true){ |res, f| res && f.exists? }
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -29,5 +29,6 @@ Dassets.configure do |c|
   c.source TEST_SUPPORT_PATH.join("app/assets") do |s|
     s.engine 'dumb', @dumb_engine
     s.engine 'useless', @useless_engine
+    s.response_headers[Factory.string] = Factory.string
   end
 end

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -25,10 +25,11 @@ class Dassets::AssetFile
       assert_equal 'file1', subject.basename
     end
 
-    should "use its source file attrs as its own" do
+    should "use its source proxy attrs as its own" do
       assert_equal subject.source_proxy.mtime.httpdate, subject.mtime
       assert_equal Rack::Utils.bytesize(subject.content), subject.size
       assert_equal "text/plain", subject.mime_type
+      assert_equal subject.source_proxy.response_headers, subject.response_headers
       assert subject.exists?
 
       null_file = Dassets::AssetFile.new('')
@@ -36,6 +37,7 @@ class Dassets::AssetFile
       assert_nil null_file.size
       assert_nil null_file.mime_type
       assert_not null_file.exists?
+      assert_equal null_file.source_proxy.response_headers, null_file.response_headers
     end
 
     should "know its source proxy" do

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -40,11 +40,11 @@ class Dassets::Server::Response
       exp_body = Body.new(@env, @asset_file)
       assert_equal exp_body, resp.body
 
-      exp_headers = {
+      exp_headers = @asset_file.response_headers.merge({
         'Content-Type'   => 'text/plain',
         'Content-Length' => Rack::Utils.bytesize(@asset_file.content).to_s,
         'Last-Modified'  => @asset_file.mtime.to_s
-      }
+      })
       assert_equal exp_headers, resp.headers
 
       assert_equal [200, exp_headers, exp_body], resp.to_rack

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -13,7 +13,7 @@ class Dassets::Source
     end
     subject{ @source }
 
-    should have_reader :path, :engines
+    should have_reader :path, :engines, :response_headers
     should have_imeth :files, :filter, :engine
 
     should "know its path and default filter" do
@@ -47,6 +47,14 @@ class Dassets::Source
     should "know its engines and return a NullEngine by default" do
       assert_kind_of ::Hash, subject.engines
       assert_kind_of Dassets::NullEngine, subject.engines['something']
+    end
+
+    should "know its response headers" do
+      assert_equal Hash.new, subject.response_headers
+
+      name, value = Factory.string, Factory.string
+      subject.response_headers[name] = value
+      assert_equal value, subject.response_headers[name]
     end
 
   end


### PR DESCRIPTION
The allows you to set some resources to be served with specific
response headers.  Use this set CORS related headers in your responses
(https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#The_HTTP_response_headers).

@jcredding ready for review.  You cool with how I piped this all the way through from the configured source to the response object?