### PR TITLE
remove ns-options as a dependency

### DIFF
--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('assert-rack-test', ["~> 1.0.3"])
   gem.add_development_dependency("sinatra",          ["~> 1.4"])
 
-  gem.add_dependency('ns-options', ["~> 1.1.6"])
-  gem.add_dependency("rack",       ["~> 1.0"])
+  gem.add_dependency("rack", ["~> 1.0"])
 
 end

--- a/lib/dassets/config.rb
+++ b/lib/dassets/config.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'ns-options'
 require 'dassets/cache'
 require 'dassets/file_store'
 require 'dassets/source'
@@ -7,9 +6,6 @@ require 'dassets/source'
 module Dassets
 
   class Config
-    include NsOptions::Proxy
-
-    option :file_store, FileStore, :default => proc{ FileStore::NullStore.new }
 
     attr_reader :sources, :combinations
 
@@ -19,6 +15,7 @@ module Dassets
       @combinations      = Hash.new{ |h, k| [k] } # digest pass-thru if none defined
       @content_cache     = Dassets::Cache::NoCache.new
       @fingerprint_cache = Dassets::Cache::NoCache.new
+      @file_store        = FileStore::NullStore.new
     end
 
     def base_url(value = nil)
@@ -28,6 +25,13 @@ module Dassets
 
     def set_base_url(value)
       @base_url = value
+    end
+
+    def file_store(value = nil)
+      if !value.nil?
+        @file_store = (value.kind_of?(FileStore) ? value : FileStore.new(value))
+      end
+      @file_store
     end
 
     def content_cache(cache = nil)

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -83,13 +83,13 @@ module Dassets
     setup do
       base_url = Factory.base_url
       Assert.stub(Dassets.config, :base_url){ base_url }
-      Dassets.config.file_store = TEST_SUPPORT_PATH.join('public').to_s
+      Dassets.config.file_store TEST_SUPPORT_PATH.join('public').to_s
       @url = Dassets['file1.txt'].url
       @url_file = Dassets.config.file_store.store_path(@url)
     end
     teardown do
       FileUtils.rm(@url_file)
-      Dassets.config.file_store = FileStore::NullStore.new
+      Dassets.config.file_store FileStore::NullStore.new
     end
 
     should "digest the asset" do

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -116,14 +116,14 @@ class Dassets::AssetFile
     setup do
       base_url = Factory.base_url
       Assert.stub(Dassets.config, :base_url){ base_url }
-      Dassets.config.file_store = TEST_SUPPORT_PATH.join('public').to_s
+      Dassets.config.file_store TEST_SUPPORT_PATH.join('public').to_s
 
       @save_path = @asset_file.digest!
       @outfile = Dassets.config.file_store.store_path(@asset_file.url)
     end
     teardown do
       FileUtils.rm(@outfile)
-      Dassets.config.file_store = Dassets::FileStore::NullStore.new
+      Dassets.config.file_store Dassets::FileStore::NullStore.new
     end
 
     should "return the asset file url" do

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -1,25 +1,21 @@
 require 'assert'
 require 'dassets/config'
 
-require 'ns-options/assert_macros'
 require 'dassets/cache'
 require 'dassets/file_store'
 
 class Dassets::Config
 
   class UnitTests < Assert::Context
-    include NsOptions::AssertMacros
-
     desc "Dassets::Config"
     setup do
       @config = Dassets::Config.new
     end
     subject{ @config }
 
-    should have_options :file_store
     should have_readers :combinations
     should have_imeths :base_url, :set_base_url
-    should have_imeths :content_cache, :fingerprint_cache
+    should have_imeths :file_store, :content_cache, :fingerprint_cache
     should have_imeths :source, :combination, :combination?
 
     should "have no base url by default" do
@@ -48,11 +44,24 @@ class Dassets::Config
       assert_kind_of Dassets::FileStore::NullStore, subject.file_store
     end
 
+    should "configure non-nil file stores" do
+      store_root = Factory.path
+      subject.file_store(store_root)
+      assert_equal store_root, subject.file_store.root
+
+      store = Dassets::FileStore.new(Factory.path)
+      subject.file_store(store)
+      assert_equal store, subject.file_store
+
+      subject.content_cache(nil)
+      assert_equal store, subject.file_store
+    end
+
     should "default its content cache" do
       assert_instance_of Dassets::Cache::NoCache, subject.content_cache
     end
 
-    should "allow configuring non-nil content caches" do
+    should "configure non-nil content caches" do
       cache = Dassets::Cache::MemCache.new
       subject.content_cache(cache)
       assert_equal cache, subject.content_cache
@@ -65,7 +74,7 @@ class Dassets::Config
       assert_instance_of Dassets::Cache::NoCache, subject.fingerprint_cache
     end
 
-    should "allow configuring non-nil fingerprint caches" do
+    should "configure non-nil fingerprint caches" do
       cache = Dassets::Cache::MemCache.new
       subject.fingerprint_cache(cache)
       assert_equal cache, subject.fingerprint_cache


### PR DESCRIPTION
This is part of getting this gem working in modern ruby versions.
We are moving away from using ns-options as a dependency b/c it
has performance issues when accessing options and on top of that
its API hasn't proven to be especially useful over a struct-like
class.

This removes the one option defined (`file_store`) using
ns-options logic.  Now, this option is handled manually but
behaves almost identically. There is one backwards incompatible
change though: there is no longer a `file_store=` writer.  I
updated the test suite to account for this.  I also checked our
apps and we seem to only be using the DSL method to set the file
store in them so this shouldn't break things.

@jcredding ready for review.