### PR TITLE
get working in modern ruby versions

### DIFF
--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert",           ["~> 2.15.1"])
-  gem.add_development_dependency('assert-rack-test', ["~> 1.0.3"])
+  gem.add_development_dependency("assert",           ["~> 2.16.1"])
+  gem.add_development_dependency('assert-rack-test', ["~> 1.0.4"])
   gem.add_development_dependency("sinatra",          ["~> 1.4"])
 
   gem.add_dependency("rack", ["~> 1.0"])

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,15 @@ require 'pry'
 
 require 'test/support/factory'
 
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end
+
 require 'pathname'
 TEST_SUPPORT_PATH = Pathname.new(File.expand_path('../support', __FILE__))
 

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -70,7 +70,7 @@ module Dassets
 
     should "return a full response on invalid-range partial content requests" do
       # see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
-      env = { 'HTTP_RANGE' => ['bytes=3-2', 'bytes=abc'].choice }
+      env = { 'HTTP_RANGE' => ['bytes=3-2', 'bytes=abc'].sample }
 
       resp = get '/file1-daa05c683a4913b268653f7a7e36a5b4.txt', {}, env
       assert_equal 200, resp.status

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -149,7 +149,7 @@ class Dassets::Server::Response
   class NonPartialBodyTests < BodyIOTests
     desc "for non/multi/invalid partial content requests"
     setup do
-      range = [nil, 'bytes=', 'bytes=0-1,2-3', 'bytes=3-2', 'bytes=abc'].choice
+      range = [nil, 'bytes=', 'bytes=0-1,2-3', 'bytes=3-2', 'bytes=abc'].sample
       env = range.nil? ? {} : { 'HTTP_RANGE' => range }
       @body = Body.new(env, @asset_file)
     end


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get up to convention for working in modern ruby versions.
This includes backfilling Array#sample so it works in 1.8.7.

@jcredding ready for review.