### PR TITLE
rework how Dassets stores its source files for faster lookups

### DIFF
--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert",           ["~> 2.16.1"])
+  gem.add_development_dependency("assert",           ["~> 2.16.3"])
   gem.add_development_dependency('assert-rack-test', ["~> 1.0.4"])
   gem.add_development_dependency("sinatra",          ["~> 1.4"])
 

--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -1,6 +1,7 @@
 require 'dassets/version'
 require 'dassets/asset_file'
 require 'dassets/config'
+require 'dassets/source_file'
 
 module Dassets
 
@@ -10,21 +11,33 @@ module Dassets
   end
 
   def self.init
-    @asset_files ||= {}
+    @asset_files  ||= {}
+    @source_files   = SourceFiles.new(self.config.sources)
   end
 
   def self.[](digest_path)
     @asset_files[digest_path] ||= AssetFile.new(digest_path)
   end
 
-  def self.source_list
-    SourceList.new(self.config.sources)
+  def self.source_files
+    @source_files
   end
 
-  module SourceList
+  module SourceFiles
+
     def self.new(sources)
-      sources.inject([]){ |list, source| list += source.files }
+      # use a hash to store the source files so in the case two source files
+      # have the same digest path, the last one *should* be correct since it
+      # was last to be configured
+      sources.inject({}) do |hash, source|
+        source.files.each do |file_path|
+          s = SourceFile.new(file_path)
+          hash[s.digest_path] = s
+        end
+        hash
+      end
     end
+
   end
 
 end

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -8,12 +8,7 @@ module Dassets
   class SourceFile
 
     def self.find_by_digest_path(path, options = nil)
-      # look in the configured source list
-      source_files = Dassets.source_list.map{ |p| self.new(p) }
-
-      # get the last matching one (in case two source files have the same digest
-      # path the last one *should* be correct since it was last to be configured)
-      source_files.select{ |s| s.digest_path == path }.last || NullSourceFile.new(path, options)
+      Dassets.source_files[path] || NullSourceFile.new(path, options)
     end
 
     attr_reader :file_path

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -41,3 +41,5 @@ Dassets.configure do |c|
     s.response_headers[Factory.string] = Factory.string
   end
 end
+
+Dassets.init

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -11,7 +11,7 @@ module Dassets
     subject{ Dassets }
 
     should have_imeths :config, :configure, :init, :[]
-    should have_imeths :source_list
+    should have_imeths :source_files
 
     should "return a `Config` instance with the `config` method" do
       assert_kind_of Config, subject.config
@@ -38,8 +38,8 @@ module Dassets
     end
 
     should "know its list of configured source files" do
-      exp_configured_list = Dassets::SourceList.new(Dassets.config.sources)
-      assert_equal exp_configured_list, subject.source_list
+      exp = Dassets::SourceFiles.new(Dassets.config.sources)
+      assert_equal exp, subject.source_files
     end
 
   end


### PR DESCRIPTION
This switches to storing the source files in a Hash rather than
an array.  The goal is to make `SourceFile.find_by_digest_path`
lookups have linear performance as the number of source files
increases.  Using a hash removes the need to scan all of the files
in the sources looking for a match.

This also switches to building the SourceFile objects stored by
the source files hash on `init`.  This means that the source files
are now "compiled" and prepped on init so that any future lookups
has linear performance.

This is all to make Dassets better (and more performant) at
fronting/hosting large sets of source files.

@jcredding ready for review.