### PR TITLE
add `reset` method for resetting asset files and the config

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -15,6 +15,11 @@ module Dassets
     @source_files   = SourceFiles.new(self.config.sources)
   end
 
+  def self.reset
+    @asset_files = {}
+    self.config.reset
+  end
+
   def self.[](digest_path)
     @asset_files[digest_path] ||= AssetFile.new(digest_path)
   end

--- a/lib/dassets/config.rb
+++ b/lib/dassets/config.rb
@@ -11,11 +11,15 @@ module Dassets
 
     def initialize
       super
-      @sources           = []
-      @combinations      = Hash.new{ |h, k| [k] } # digest pass-thru if none defined
+      self.reset
       @content_cache     = Dassets::Cache::NoCache.new
       @fingerprint_cache = Dassets::Cache::NoCache.new
       @file_store        = FileStore::NullStore.new
+    end
+
+    def reset
+      @sources      = []
+      @combinations = Hash.new{ |h, k| [k] } # digest pass-thru if none defined
     end
 
     def base_url(value = nil)

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -14,9 +14,25 @@ class Dassets::Config
     subject{ @config }
 
     should have_readers :combinations
+    should have_imeths :reset
     should have_imeths :base_url, :set_base_url
     should have_imeths :file_store, :content_cache, :fingerprint_cache
     should have_imeths :source, :combination, :combination?
+
+    should "reset its sources and combination on `reset`" do
+      assert_empty subject.sources
+      assert_empty subject.combinations
+
+      path = Factory.path
+      subject.source(path)
+      subject.combination path, [Factory.path]
+      assert_equal 1, subject.sources.size
+      assert_equal 1, subject.combinations.size
+
+      subject.reset
+      assert_empty subject.sources
+      assert_empty subject.combinations
+    end
 
     should "have no base url by default" do
       assert_nil subject.base_url
@@ -84,7 +100,7 @@ class Dassets::Config
     end
 
     should "register new sources with the `source` method" do
-      path = '/path/to/app/assets'
+      path = Factory.path
       filter = proc{ |paths| [] }
       subject.source(path){ |s| s.filter(&filter) }
 

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -10,17 +10,30 @@ module Dassets
     desc "Dassets"
     subject{ Dassets }
 
-    should have_imeths :config, :configure, :init, :[]
-    should have_imeths :source_files
+    should have_imeths :config, :configure, :init, :reset
+    should have_imeths :[], :source_files
 
     should "return a `Config` instance with the `config` method" do
       assert_kind_of Config, subject.config
     end
 
+    should "know how to reset itself" do
+      config_reset_called = false
+      Assert.stub(subject.config, :reset){ config_reset_called = true }
+
+      file1 = subject['nested/file3.txt']
+
+      subject.reset
+
+      file2 = subject['nested/file3.txt']
+      assert_not_same file2, file1
+      assert_true config_reset_called
+    end
+
     should "return asset files given a their digest path using the index operator" do
       file = subject['nested/file3.txt']
 
-      assert_kind_of Dassets::AssetFile, file
+      assert_kind_of subject::AssetFile, file
       assert_equal 'nested/file3.txt', file.digest_path
       assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.fingerprint
     end
@@ -38,7 +51,7 @@ module Dassets
     end
 
     should "know its list of configured source files" do
-      exp = Dassets::SourceFiles.new(Dassets.config.sources)
+      exp = Dassets::SourceFiles.new(subject.config.sources)
       assert_equal exp, subject.source_files
     end
 


### PR DESCRIPTION
This is handy in testing to make sure Dassets is in a known state
before running tests for configuring Dassets.  This came up in
testing a gem that uses Dassets.

@jcredding ready for review.  Wish our tests would have revealed the need of this before I rolled that last minor version - oh well.