### PR TITLE
error loudly if requesting a digest path that can't be digested

### DIFF
--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -11,7 +11,7 @@ module Dassets
     subject{ Dassets }
 
     should have_imeths :config, :configure, :init, :reset
-    should have_imeths :[], :source_files
+    should have_imeths :[], :source_files, :combinations
 
     should "return a `Config` instance with the `config` method" do
       assert_kind_of Config, subject.config
@@ -45,14 +45,20 @@ module Dassets
       assert_same file2, file1
     end
 
-    should "return an asset file that doesn't exist if digest path not found" do
-      file = subject['path/not/found.txt']
-      assert_not file.exists?
+    should "complain if digest path is not found using the index operator" do
+      assert_raises AssetFileError do
+        subject['path/not/found.txt']
+      end
     end
 
     should "know its list of configured source files" do
       exp = Dassets::SourceFiles.new(subject.config.sources)
       assert_equal exp, subject.source_files
+    end
+
+    should "know its configured combinations" do
+      exp = subject.config.combinations
+      assert_equal exp, subject.combinations
     end
 
   end

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'dassets/server/request'
 
+require 'dassets'
 require 'dassets/asset_file'
 
 class Dassets::Server::Request
@@ -45,28 +46,28 @@ class Dassets::Server::Request
       req = file_request('GET', '/file1-d41d8cd98f00b204e9800998ecf8427e.txt')
       assert req.for_asset_file?
 
-      # no find on invalid fingerprint
-      req = file_request('GET', '/file1-daa05c683a4913b268653f7a7e36a.txt')
+      # not find an invalid fingerprint
+      req = file_request('GET', '/file1-abc123.txt')
       assert_not req.for_asset_file?
 
-      # no find on missing fingerprint
+      # not find a missing fingerprint
       req = file_request('HEAD', '/file1.txt')
       assert_not req.for_asset_file?
 
-      # no find on unknown file
+      # not find an unknown file with a missing fingerprint
       req = file_request('GET', '/some-file.txt')
       assert_not req.for_asset_file?
 
-      # no find on unknown file with an fingerprint
+      # complain with an unknown file with a valid fingerprint
       req = file_request('GET', '/some-file-daa05c683a4913b268653f7a7e36a5b4.txt')
-      assert_not req.for_asset_file?
+      assert_raises(Dassets::AssetFileError){ req.for_asset_file? }
     end
 
-    should "return an asset path and an empty asset file if request not for asset file" do
+    should "return an asset path and complain if request not for asset file" do
       req = file_request('GET', '/some-file.txt')
 
       assert_equal '', req.asset_path
-      assert_equal Dassets::AssetFile.new(''), req.asset_file
+      assert_raises(Dassets::AssetFileError){ req.asset_file }
     end
 
     protected

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'dassets/server/response'
 
 require 'rack/utils'
+require 'dassets'
 require 'dassets/asset_file'
 
 class Dassets::Server::Response
@@ -59,13 +60,9 @@ class Dassets::Server::Response
     end
 
     should "handle not found files" do
-      af   = Dassets['not-found-file.txt']
-      resp = Dassets::Server::Response.new(@env, af)
-
-      assert_equal 404,                         resp.status
-      assert_equal ['Not Found'],               resp.body
-      assert_equal Rack::Utils::HeaderHash.new, resp.headers
-      assert_equal [404, {}, ['Not Found']],    resp.to_rack
+      assert_raises(Dassets::AssetFileError) do
+        Dassets['not-found-file.txt']
+      end
     end
 
   end


### PR DESCRIPTION
The goal here is to help find errors in Dassets configuration and
setup more easily.  Before, if you messed up your Dassets config
or if you typo'd a digest path, Dassets would just return an
"empty" asset file as kind of a null pattern placeholder for the
asset being requested.  The developer wouldn't realize there was
a problem until a request came for the asset and returned a 404.
This 404 would cause the page to render incorrectly but give no
clue to the dev that there was a problem with Dassets.  The only
clue the dev would have is the asset path would end with a dash
and no digest fingerprint.

This isn't very helpful.  A better solution would be for Dassets
to error loudly with detailed error info so the dev would clearly
know the problem is with Dassets and have some info to help debug
the problem.  This error can now be caught in automated test
suites or reported via production exception trackers, etc.

So, this updates the Dassets index operator `[]` to now check the
asset file it will return for a fingerprint.  If it has no
fingerprint that means there was a problem digesting the asset
file.  Either there is no source file for that digest path or
there is no combination for that digest path or there is a combo
but the combo has an incorrect source file definition, etc.

In this case, Dassets raises a custom exception with the digest
path requested.  In addition, it outputs the defined combinations
with sorted combo digest paths and also outputs the sorted digest
paths of the configured source files.  This info can be used to
debug missing/typo'd digest paths (which is most likely the reason
for the problem.

![imageh75uy](https://user-images.githubusercontent.com/82110/30967337-9f0a2622-a421-11e7-86f1-102c84104aa2.jpg)

@jcredding ready for review.
