### PR TITLE
add `asset_file` method that doesn't error to compliment `[]` method

### DIFF
--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -20,8 +20,12 @@ module Dassets
     self.config.reset
   end
 
+  def self.asset_file(digest_path)
+    @asset_files[digest_path] ||= AssetFile.new(digest_path)
+  end
+
   def self.[](digest_path)
-    @asset_files[digest_path] ||= AssetFile.new(digest_path).tap do |af|
+    self.asset_file(digest_path).tap do |af|
       if af.fingerprint.nil?
         msg = "error digesting `#{digest_path}`.\n\nMake sure Dassets has " \
               "either a combination or source file for this digest path. If " \
@@ -36,7 +40,7 @@ module Dassets
           values = Dassets.combinations[key].sort
           msg << (
             ["#{bullet}#{values.first}"] +
-            values[1..-1].map{ |v| "#{' '*bullet.size}#{v}" }
+            (values[1..-1] || []).map{ |v| "#{' '*bullet.size}#{v}" }
           ).join("\n")
           msg << "\n\n"
         end

--- a/lib/dassets/server/request.rb
+++ b/lib/dassets/server/request.rb
@@ -33,7 +33,7 @@ class Dassets::Server
     end
 
     def asset_file
-      @asset_file ||= Dassets[asset_path]
+      @asset_file ||= Dassets.asset_file(asset_path)
     end
 
     private

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -11,7 +11,7 @@ module Dassets
     subject{ Dassets }
 
     should have_imeths :config, :configure, :init, :reset
-    should have_imeths :[], :source_files, :combinations
+    should have_imeths :asset_file, :[], :source_files, :combinations
 
     should "return a `Config` instance with the `config` method" do
       assert_kind_of Config, subject.config
@@ -30,15 +30,26 @@ module Dassets
       assert_true config_reset_called
     end
 
-    should "return asset files given a their digest path using the index operator" do
+    should "return asset files given their digest path " do
+      file = subject.asset_file('nested/file3.txt')
+
+      assert_kind_of subject::AssetFile, file
+      assert_equal 'nested/file3.txt',                 file.digest_path
+      assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.fingerprint
+
       file = subject['nested/file3.txt']
 
       assert_kind_of subject::AssetFile, file
-      assert_equal 'nested/file3.txt', file.digest_path
+      assert_equal 'nested/file3.txt',                 file.digest_path
       assert_equal 'd41d8cd98f00b204e9800998ecf8427e', file.fingerprint
     end
 
     should "cache asset files" do
+      file1 = subject.asset_file('nested/file3.txt')
+      file2 = subject.asset_file('nested/file3.txt')
+
+      assert_same file2, file1
+
       file1 = subject['nested/file3.txt']
       file2 = subject['nested/file3.txt']
 
@@ -46,6 +57,9 @@ module Dassets
     end
 
     should "complain if digest path is not found using the index operator" do
+      assert_nothing_raised do
+        subject.asset_file('path/not/found.txt')
+      end
       assert_raises AssetFileError do
         subject['path/not/found.txt']
       end

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -1,7 +1,6 @@
 require 'assert'
 require 'dassets/server/request'
 
-require 'dassets'
 require 'dassets/asset_file'
 
 class Dassets::Server::Request
@@ -58,16 +57,16 @@ class Dassets::Server::Request
       req = file_request('GET', '/some-file.txt')
       assert_not req.for_asset_file?
 
-      # complain with an unknown file with a valid fingerprint
+      # not find an unknown file with a valid fingerprint
       req = file_request('GET', '/some-file-daa05c683a4913b268653f7a7e36a5b4.txt')
-      assert_raises(Dassets::AssetFileError){ req.for_asset_file? }
+      assert_not req.for_asset_file?
     end
 
-    should "return an asset path and complain if request not for asset file" do
+    should "return an empty path and file if request not for an asset file" do
       req = file_request('GET', '/some-file.txt')
 
       assert_equal '', req.asset_path
-      assert_raises(Dassets::AssetFileError){ req.asset_file }
+      assert_equal Dassets::AssetFile.new(''), req.asset_file
     end
 
     protected

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -2,7 +2,6 @@ require 'assert'
 require 'dassets/server/response'
 
 require 'rack/utils'
-require 'dassets'
 require 'dassets/asset_file'
 
 class Dassets::Server::Response
@@ -60,9 +59,13 @@ class Dassets::Server::Response
     end
 
     should "handle not found files" do
-      assert_raises(Dassets::AssetFileError) do
-        Dassets['not-found-file.txt']
-      end
+      af   = Dassets.asset_file('not-found-file.txt')
+      resp = Dassets::Server::Response.new(@env, af)
+
+      assert_equal 404,                         resp.status
+      assert_equal ['Not Found'],               resp.body
+      assert_equal Rack::Utils::HeaderHash.new, resp.headers
+      assert_equal [404, {}, ['Not Found']],    resp.to_rack
     end
 
   end


### PR DESCRIPTION
We need a method that looks up the asset file from a digest path
so that the request class can use it.  Requests should never hard
error in this situation b/c they need to pass on the request if
the request is not for an asset file.  If it errors, you never get
a chance to check if the request was for an asset file or not.

This switches the request to use `asset_file` method that doesn't
error and reverts the request tests to their pre-PR-83 logic.
Changing the request tests in PR 83 should have been a red-flag
that the request behavior was changing but I blew right past that
warning.  Oh well, this cleans things up.

Note: this also fixes a bug where the hard error msg from PR 83 
won't build if you have a combination with no values.  I noticed
this while debugging this problem.

See #83 for reference.

@jcredding ready for review.