### PR TITLE
update to the latest Assert 2.19.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,3 @@ ruby "~> 2.5"
 gemspec
 
 gem "pry", "~> 0.12.2"
-gem "assert-rack-test", path: "/Users/kelly/projects/redding/gems/assert-rack-test"

--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = "~> 2.5"
 
-  gem.add_development_dependency("assert",           ["~> 2.18.4"])
-  gem.add_development_dependency('assert-rack-test', ["~> 1.0.5"])
+  gem.add_development_dependency("assert",           ["~> 2.19.0"])
+  gem.add_development_dependency('assert-rack-test', ["~> 1.1.0"])
   gem.add_development_dependency("sinatra",          ["~> 2.1"])
 
   gem.add_dependency("rack", ["~> 2.1"])

--- a/lib/dassets/server/response.rb
+++ b/lib/dassets/server/response.rb
@@ -89,9 +89,13 @@ class Dassets::Server::Response
     end
 
     def ==(other_body)
-      self.asset_file  == other_body.asset_file  &&
-      self.range_begin == other_body.range_begin &&
-      self.range_end   == other_body.range_end
+      if other_body.is_a?(self.class)
+        self.asset_file  == other_body.asset_file  &&
+        self.range_begin == other_body.range_begin &&
+        self.range_end   == other_body.range_end
+      else
+        super
+      end
     end
 
     private

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -65,7 +65,11 @@ class Dassets::SourceFile
   end
 
   def ==(other_source_file)
-    self.file_path == other_source_file.file_path
+    if other_source_file.is_a?(self.class)
+      self.file_path == other_source_file.file_path
+    else
+      super
+    end
   end
 
   private
@@ -112,6 +116,10 @@ class Dassets::NullSourceFile < Dassets::SourceFile
   end
 
   def ==(other_source_file)
-    self.file_path == other_source_file.file_path
+    if other_source_file.is_a?(self.class)
+      self.file_path == other_source_file.file_path
+    else
+      super
+    end
   end
 end

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -99,19 +99,19 @@ class Dassets::AssetFile
     should "not memoize its attributes" do
       url1 = subject.url
       url2 = subject.url
-      assert_that(url1).is_not_the_same_as(url2)
+      assert_that(url1).is_not(url2)
 
       fingerprint1 = subject.fingerprint
       fingerprint2 = subject.fingerprint
-      assert_that(fingerprint1).is_not_the_same_as(fingerprint2)
+      assert_that(fingerprint1).is_not(fingerprint2)
 
       content1 = subject.content
       content2 = subject.content
-      assert_that(content1).is_not_the_same_as(content2)
+      assert_that(content1).is_not(content2)
 
       mtime1 = subject.mtime
       mtime2 = subject.mtime
-      assert_that(mtime1).is_not_the_same_as(mtime2)
+      assert_that(mtime1).is_not(mtime2)
     end
   end
 

--- a/test/unit/cache_tests.rb
+++ b/test/unit/cache_tests.rb
@@ -11,7 +11,7 @@ class Dassets::MemCache
     should "cache given key/value pairs in memory" do
       val = []
       subject['something'] = val
-      assert_that(subject['something']).is_the_same_as(val)
+      assert_that(subject['something']).is(val)
     end
   end
 end
@@ -26,7 +26,7 @@ class Dassets::NoCache
     should "not cache given key/value pairs in memory" do
       val = []
       subject['something'] = val
-      assert_that(subject['something']).is_not_the_same_as(val)
+      assert_that(subject['something']).is_not(val)
     end
   end
 end

--- a/test/unit/dassets_tests.rb
+++ b/test/unit/dassets_tests.rb
@@ -25,7 +25,7 @@ module Dassets
       subject.reset
 
       file2 = subject["nested/file3.txt"]
-      assert_that(file2).is_not_the_same_as(file1)
+      assert_that(file2).is_not(file1)
       assert_that(config_reset_called).is_true
     end
 
@@ -41,7 +41,7 @@ module Dassets
       file1 = subject.asset_file("nested/file3.txt")
       file2 = subject.asset_file("nested/file3.txt")
 
-      assert_that(file2).is_the_same_as(file1)
+      assert_that(file2).is(file1)
     end
 
     should "complain if digest path is not found using the index operator" do
@@ -49,9 +49,7 @@ module Dassets
         subject.asset_file("path/not/found.txt")
       }).does_not_raise
 
-      assert_that(-> {
-        subject["path/not/found.txt"]
-      }).raises(AssetFileError)
+      assert_that { subject["path/not/found.txt"] }.raises(AssetFileError)
     end
 
     should "know its list of configured source files" do

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -15,8 +15,8 @@ class Dassets::Engine
     end
 
     should "raise NotImplementedError on `ext` and `compile`" do
-      assert_that(-> { subject.ext("foo") }).raises(NotImplementedError)
-      assert_that(-> { subject.compile("some content") })
+      assert_that { subject.ext("foo") }.raises(NotImplementedError)
+      assert_that { subject.compile("some content") }
         .raises(NotImplementedError)
     end
   end

--- a/test/unit/source_file_tests.rb
+++ b/test/unit/source_file_tests.rb
@@ -42,7 +42,7 @@ class Dassets::SourceFile
     should "not memoize its compiled source" do
       compiled1 = subject.compiled
       compiled2 = subject.compiled
-      assert_that(compiled2).is_not_the_same_as(compiled1)
+      assert_that(compiled2).is_not(compiled1)
     end
 
     should "know if it exists" do
@@ -54,15 +54,14 @@ class Dassets::SourceFile
     end
 
     should "use the response headers of its source as its response headers" do
-      assert_that(subject.response_headers)
-        .is_the_same_as(subject.source.response_headers)
+      assert_that(subject.response_headers).is(subject.source.response_headers)
     end
 
     should "be findable by its digest path" do
       found = Dassets::SourceFile.find_by_digest_path(subject.digest_path)
 
       assert_that(found).equals(subject)
-      assert_that(found).is_not_the_same_as(subject)
+      assert_that(found).is_not(subject)
     end
   end
 
@@ -101,7 +100,7 @@ class Dassets::NullSourceFile
       found = Dassets::SourceFile.find_by_digest_path("not/found/digest/path")
 
       assert_that(found).equals(null_src)
-      assert_that(found).is_not_the_same_as(null_src)
+      assert_that(found).is_not(null_src)
 
       assert_that(null_src.file_path).equals("")
       assert_that(null_src.exists?).equals(false)

--- a/test/unit/source_proxy_tests.rb
+++ b/test/unit/source_proxy_tests.rb
@@ -168,11 +168,11 @@ class Dassets::SourceProxy
     should "not cache its source content/fingerprint" do
       content1 = subject.content
       content2 = subject.content
-      assert_that(content2).is_not_the_same_as(content1)
+      assert_that(content2).is_not(content1)
 
       finger1 = subject.fingerprint
       finger2 = subject.fingerprint
-      assert_that(finger2).is_not_the_same_as(finger1)
+      assert_that(finger2).is_not(finger1)
     end
   end
 
@@ -192,11 +192,11 @@ class Dassets::SourceProxy
     should "cache its source content/fingerprint in memory" do
       content1 = subject.content
       content2 = subject.content
-      assert_that(content2).is_the_same_as(content1)
+      assert_that(content2).is(content1)
 
       finger1 = subject.fingerprint
       finger2 = subject.fingerprint
-      assert_that(finger2).is_the_same_as(finger1)
+      assert_that(finger2).is(finger1)
     end
   end
 end


### PR DESCRIPTION
This updates to the latest Assert. This is part of keeping up to
date on the dependencies. This also cleans up the tests based on
the new APIs offered in Assert.