### PR TITLE
update to glob for source files honoring any symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Dassets.configure do |c|
 end
 ```
 
-This configuration says that Dassets, for assets in `/path/to/assets`, should 1) ignore any files beginning in `_` 2) process any files ending in `.erb` with the Erb engine and 3) process any files ending in `.scss` with the Sass engine (using 'scss' syntax).
+This configuration says that Dassets, for assets in `/path/to/assets`, should 1) ignore any files beginning in `_` 2) process any files ending in `.erb` with the Erb engine and 3) process any files ending in `.scss` with the Sass engine (using scss syntax).
 
 The goal here is to allow you to control how certain asset files are handled based on their location root.  This is handy for 3rd-paty gems that provide asset source files (such as [Romo](https://github.com/redding/romo)).  See https://github.com/redding/romo/blob/master/lib/romo/dassets.rb for an example of how Romo integrates with Dassets.
 

--- a/dassets.gemspec
+++ b/dassets.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "dassets/version"
 
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.summary     = %q{Digested asset files}
   gem.description = %q{Digest and serve HTML asset files}
   gem.homepage    = "http://github.com/redding/dassets"
-  gem.license     = 'MIT'
+  gem.license     = "MIT"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = "~> 2.5"
 
   gem.add_development_dependency("assert",           ["~> 2.19.0"])
-  gem.add_development_dependency('assert-rack-test', ["~> 1.1.0"])
+  gem.add_development_dependency("assert-rack-test", ["~> 1.1.0"])
   gem.add_development_dependency("sinatra",          ["~> 2.1"])
 
   gem.add_dependency("rack", ["~> 2.1"])

--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -45,7 +45,7 @@ module Dassets
           values = Dassets.combinations[key].sort
           msg << (
             ["#{bullet}#{values.first}"] +
-            (values[1..-1] || []).map{ |v| "#{' '*bullet.size}#{v}" }
+            (values[1..-1] || []).map{ |v| "#{" "*bullet.size}#{v}" }
           ).join("\n")
           msg << "\n\n"
         end

--- a/lib/dassets.rb
+++ b/lib/dassets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dassets/version"
 require "dassets/asset_file"
 require "dassets/config"
@@ -32,7 +34,7 @@ module Dassets
     self.asset_file(digest_path).tap do |af|
       if af.fingerprint.nil?
         msg =
-          "error digesting `#{digest_path}`.\n\nMake sure Dassets has " \
+          +"error digesting `#{digest_path}`.\n\nMake sure Dassets has " \
           "either a combination or source file for this digest path. If " \
           "this path is for a combination, make sure Dassets has either " \
           "a combination or source file for each digest path of the " \

--- a/lib/dassets/asset_file.rb
+++ b/lib/dassets/asset_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dassets/source_proxy"
 require "rack/utils"
 require "rack/mime"

--- a/lib/dassets/cache.rb
+++ b/lib/dassets/cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 module Dassets; end

--- a/lib/dassets/config.rb
+++ b/lib/dassets/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pathname"
 require "dassets/cache"
 require "dassets/file_store"

--- a/lib/dassets/engine.rb
+++ b/lib/dassets/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Dassets; end
 
 class Dassets::Engine

--- a/lib/dassets/file_store.rb
+++ b/lib/dassets/file_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "thread"
 
 module Dassets; end

--- a/lib/dassets/server.rb
+++ b/lib/dassets/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dassets/server/request"
 require "dassets/server/response"
 

--- a/lib/dassets/server/request.rb
+++ b/lib/dassets/server/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rack"
 
 module Dassets; end

--- a/lib/dassets/server/response.rb
+++ b/lib/dassets/server/response.rb
@@ -14,7 +14,7 @@ class Dassets::Server::Response
     @status, @headers, @body = if env["HTTP_IF_MODIFIED_SINCE"] == mtime
       [
         304,
-        Rack::Utils::HeaderHash.new('Last-Modified' => mtime),
+        Rack::Utils::HeaderHash.new("Last-Modified" => mtime),
         [],
       ]
     elsif !@asset_file.exists?
@@ -83,7 +83,7 @@ class Dassets::Server::Response
     end
 
     def inspect
-      "#<#{self.class}:#{'0x0%x' % (self.object_id << 1)} " \
+      "#<#{self.class}:#{"0x0%x" % (self.object_id << 1)} " \
         "digest_path=#{self.asset_file.digest_path} " \
         "range_begin=#{self.range_begin} range_end=#{self.range_end}>"
     end

--- a/lib/dassets/server/response.rb
+++ b/lib/dassets/server/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rack/response"
 require "rack/utils"
 require "rack/mime"

--- a/lib/dassets/source.rb
+++ b/lib/dassets/source.rb
@@ -27,8 +27,13 @@ class Dassets::Source
 
   private
 
+  # Use "**{,/*/**}/*" to glob following symlinks and returning immediate-child
+  # matches. See https://stackoverflow.com/a/2724048.
   def glob_files
-    Dir.glob(File.join(@path, "**/*")).reject!{ |p| !File.file?(p) }
+    Dir
+      .glob(File.join(@path, "**{,/*/**}/*"))
+      .uniq
+      .reject{ |path| !File.file?(path) }
   end
 
   def apply_filter(files)

--- a/lib/dassets/source.rb
+++ b/lib/dassets/source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "dassets/engine"
 
 module Dassets; end

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -13,7 +13,7 @@ class Dassets::SourceFile
 
   def initialize(file_path)
     @file_path = file_path.to_s
-    @ext_list  = File.basename(@file_path).split('.').reverse
+    @ext_list  = File.basename(@file_path).split(".").reverse
   end
 
   # Get the last matching one (in the case two sources with the same path are

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fileutils"
 require "dassets"
 require "dassets/asset_file"

--- a/lib/dassets/source_proxy.rb
+++ b/lib/dassets/source_proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "digest/md5"
 require "dassets/cache"
 require "dassets/source_file"

--- a/lib/dassets/version.rb
+++ b/lib/dassets/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Dassets
   VERSION = "0.14.5"
 end

--- a/test/support/source_files/linked
+++ b/test/support/source_files/linked
@@ -1,0 +1,1 @@
+../linked_source_files/

--- a/test/support/source_files/linked_file2.txt
+++ b/test/support/source_files/linked_file2.txt
@@ -1,0 +1,1 @@
+../linked_source_files/linked_file.txt

--- a/test/unit/asset_file_tests.rb
+++ b/test/unit/asset_file_tests.rb
@@ -11,7 +11,7 @@ class Dassets::AssetFile
     subject { @asset_file }
 
     setup do
-      @asset_file = Dassets::AssetFile.new('file1.txt')
+      @asset_file = Dassets::AssetFile.new("file1.txt")
     end
 
     should have_readers :digest_path, :dirname, :extname, :basename, :source_proxy
@@ -33,7 +33,7 @@ class Dassets::AssetFile
       .equals(subject.source_proxy.response_headers)
       assert_that(subject.exists?).is_true
 
-      null_file = Dassets::AssetFile.new('')
+      null_file = Dassets::AssetFile.new("")
       assert_that(null_file.mtime).is_nil
       assert_that(null_file.size).is_nil
       assert_that(null_file.mime_type).is_nil

--- a/test/unit/cache_tests.rb
+++ b/test/unit/cache_tests.rb
@@ -10,8 +10,8 @@ class Dassets::MemCache
 
     should "cache given key/value pairs in memory" do
       val = []
-      subject['something'] = val
-      assert_that(subject['something']).is(val)
+      subject["something"] = val
+      assert_that(subject["something"]).is(val)
     end
   end
 end
@@ -25,8 +25,8 @@ class Dassets::NoCache
 
     should "not cache given key/value pairs in memory" do
       val = []
-      subject['something'] = val
-      assert_that(subject['something']).is_not(val)
+      subject["something"] = val
+      assert_that(subject["something"]).is_not(val)
     end
   end
 end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -112,31 +112,31 @@ class Dassets::Config
 
     should "know its combinations and return the keyed digest path by default" do
       assert_that(subject.combinations).is_kind_of(::Hash)
-      assert_that(subject.combinations['some/digest.path'])
-        .equals(['some/digest.path'])
+      assert_that(subject.combinations["some/digest.path"])
+        .equals(["some/digest.path"])
     end
 
     should "allow registering new combinations" do
-      assert_that(subject.combinations['some/digest.path'])
-        .equals(['some/digest.path'])
-      exp_combination = ['some/other.path', 'and/another.path']
-      subject.combination 'some/digest.path', exp_combination
-      assert_that(subject.combinations['some/digest.path'])
+      assert_that(subject.combinations["some/digest.path"])
+        .equals(["some/digest.path"])
+      exp_combination = ["some/other.path", "and/another.path"]
+      subject.combination "some/digest.path", exp_combination
+      assert_that(subject.combinations["some/digest.path"])
         .equals(exp_combination)
 
-      assert_that(subject.combinations['test/digest.path'])
-        .equals(['test/digest.path'])
-      subject.combination 'test/digest.path', ['some/other.path']
-      assert_that(subject.combinations['test/digest.path'])
-        .equals(['some/other.path'])
+      assert_that(subject.combinations["test/digest.path"])
+        .equals(["test/digest.path"])
+      subject.combination "test/digest.path", ["some/other.path"]
+      assert_that(subject.combinations["test/digest.path"])
+        .equals(["some/other.path"])
     end
 
     should "know which digest paths are actual combinations and which are "\
            "just pass-thrus" do
-      subject.combination 'some/combination.path', ['some.path', 'another.path']
+      subject.combination "some/combination.path", ["some.path", "another.path"]
 
-      assert_that(subject.combination?('some/combination.path')).is_true
-      assert_that(subject.combination?('some/non-combo.path')).is_false
+      assert_that(subject.combination?("some/combination.path")).is_true
+      assert_that(subject.combination?("some/non-combo.path")).is_false
     end
   end
 end

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -36,7 +36,7 @@ class Dassets::NullEngine
     end
 
     should "return the given extension on `ext`" do
-      assert_that(subject.ext('foo')).equals("foo")
+      assert_that(subject.ext("foo")).equals("foo")
     end
 
     should "return the given input on `compile" do

--- a/test/unit/file_store_tests.rb
+++ b/test/unit/file_store_tests.rb
@@ -62,7 +62,7 @@ class Dassets::NullFileStore
     end
 
     should "know its root" do
-      assert_that(subject.root).equals('')
+      assert_that(subject.root).equals("")
     end
 
     should "return the store path on save but not save a file" do

--- a/test/unit/server/request_tests.rb
+++ b/test/unit/server/request_tests.rb
@@ -10,7 +10,7 @@ class Dassets::Server::Request
 
     setup do
       @path = "/file1-daa05c683a4913b268653f7a7e36a5b4.txt"
-      @req = file_request('GET', @path)
+      @req = file_request("GET", @path)
     end
 
     should have_imeths :dassets_base_url
@@ -19,7 +19,7 @@ class Dassets::Server::Request
     should "know its attributes" do
       assert_that(subject.dassets_base_url).equals(Dassets.config.base_url.to_s)
       assert_that(subject.path_info).equals(@path)
-      assert_that(subject.asset_path).equals('file1.txt')
+      assert_that(subject.asset_path).equals("file1.txt")
       assert_that(subject.asset_file).equals(Dassets["file1.txt"])
     end
 
@@ -93,8 +93,8 @@ class Dassets::Server::Request
     end
 
     should "remove the configured base url from the path info" do
-      assert_that(file_request('GET', @path).path_info).equals(@path)
-      assert_that(file_request('GET', "#{@new_base_url}#{@path}").path_info)
+      assert_that(file_request("GET", @path).path_info).equals(@path)
+      assert_that(file_request("GET", "#{@new_base_url}#{@path}").path_info)
         .equals(@path)
     end
   end

--- a/test/unit/server/response_tests.rb
+++ b/test/unit/server/response_tests.rb
@@ -27,7 +27,7 @@ class Dassets::Server::Response
       assert_that(resp.body).equals([])
 
       exp_headers =
-        Rack::Utils::HeaderHash.new('Last-Modified' => @asset_file.mtime.to_s)
+        Rack::Utils::HeaderHash.new("Last-Modified" => @asset_file.mtime.to_s)
       assert_that(resp.headers).equals(exp_headers)
       assert_that(resp.to_rack).equals([304, exp_headers.to_hash, []])
     end
@@ -64,9 +64,9 @@ class Dassets::Server::Response
       resp = Dassets::Server::Response.new(@env, af)
 
       assert_that(resp.status).equals(404)
-      assert_that(resp.body).equals(['Not Found'])
+      assert_that(resp.body).equals(["Not Found"])
       assert_that(resp.headers).equals(Rack::Utils::HeaderHash.new)
-      assert_that(resp.to_rack).equals([404, {}, ['Not Found']])
+      assert_that(resp.to_rack).equals([404, {}, ["Not Found"]])
     end
   end
 
@@ -118,7 +118,7 @@ class Dassets::Server::Response
       Assert.stub(same_af_same_range, :range_end){ subject.range_end }
       assert_that(subject).equals(same_af_same_range)
 
-      other_af_same_range = Body.new(@env, Dassets['file2.txt'])
+      other_af_same_range = Body.new(@env, Dassets["file2.txt"])
       Assert.stub(other_af_same_range, :range_begin){ subject.range_begin }
       Assert.stub(other_af_same_range, :range_end){ subject.range_end }
       assert_that(subject).does_not_equal(other_af_same_range)
@@ -140,7 +140,7 @@ class Dassets::Server::Response
       @min_num_chunks = 3
       @num_chunks     = @min_num_chunks + Factory.integer(3)
 
-      content = 'a' * (@num_chunks * Body::CHUNK_SIZE)
+      content = "a" * (@num_chunks * Body::CHUNK_SIZE)
       Assert.stub(@asset_file, :content){ content }
     end
   end
@@ -149,8 +149,8 @@ class Dassets::Server::Response
     desc "for non/multi/invalid partial content requests"
 
     setup do
-      range = [nil, 'bytes=', 'bytes=0-1,2-3', 'bytes=3-2', 'bytes=abc'].sample
-      env = range.nil? ? {} : { 'HTTP_RANGE' => range }
+      range = [nil, "bytes=", "bytes=0-1,2-3", "bytes=3-2", "bytes=abc"].sample
+      env = range.nil? ? {} : { "HTTP_RANGE" => range }
       @body = Body.new(env, @asset_file)
     end
 
@@ -177,7 +177,7 @@ class Dassets::Server::Response
 
       assert_that(chunks.size).equals(@num_chunks)
       assert_that(chunks.first.size).equals(subject.class::CHUNK_SIZE)
-      assert_that(chunks.join('')).equals(@asset_file.content)
+      assert_that(chunks.join("")).equals(@asset_file.content)
     end
   end
 
@@ -191,7 +191,7 @@ class Dassets::Server::Response
       @partial_size   = @partial_chunks * Body::CHUNK_SIZE
       @partial_end    = @partial_begin + (@partial_size-1)
 
-      @env = { 'HTTP_RANGE' => "bytes=#{@partial_begin}-#{@partial_end}" }
+      @env = { "HTTP_RANGE" => "bytes=#{@partial_begin}-#{@partial_end}" }
     end
   end
 
@@ -228,7 +228,7 @@ class Dassets::Server::Response
       assert_that(chunks.first.size).equals(subject.class::CHUNK_SIZE)
 
       exp = @asset_file.content[@partial_begin..@partial_end]
-      assert_that(chunks.join('')).equals(exp)
+      assert_that(chunks.join("")).equals(exp)
     end
   end
 
@@ -263,7 +263,7 @@ class Dassets::Server::Response
 
       assert_that(chunks.size).equals(@num_chunks)
       assert_that(chunks.first.size).equals(subject.class::CHUNK_SIZE)
-      assert_that(chunks.join('')).equals(@asset_file.content)
+      assert_that(chunks.join("")).equals(@asset_file.content)
     end
   end
 end

--- a/test/unit/source_file_tests.rb
+++ b/test/unit/source_file_tests.rb
@@ -11,7 +11,7 @@ class Dassets::SourceFile
     subject { Dassets::SourceFile.new(@file_path) }
 
     setup do
-      @file_path = TEST_SUPPORT_PATH.join('app/assets/file1.txt').to_s
+      @file_path = TEST_SUPPORT_PATH.join("app/assets/file1.txt").to_s
     end
 
     should have_readers :file_path
@@ -70,7 +70,7 @@ class Dassets::SourceFile
 
     setup do
       @file_path =
-        TEST_SUPPORT_PATH.join('app/assets/nested/a-thing.txt.useless.dumb')
+        TEST_SUPPORT_PATH.join("app/assets/nested/a-thing.txt.useless.dumb")
     end
 
     should "build the digest path appropriately" do
@@ -123,11 +123,11 @@ class Dassets::NullSourceFile
       }
       Dassets::SourceFile.find_by_digest_path("not/found/digest/path", **options)
 
-      exp = ['not/found/digest/path', options]
+      exp = ["not/found/digest/path", options]
       assert_that(null_src_new_called_with).equals(exp)
     end
 
-    should "'proxy' the digest path if the path is a combination" do
+    should "proxy the digest path if the path is a combination" do
       src_proxy      = Dassets::SourceProxy.new("file3.txt")
       null_combo_src = Dassets::NullSourceFile.new("file3.txt")
 

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -27,7 +27,9 @@ class Dassets::Source
         @source_path.join("test1.txt").to_s,
         @source_path.join("_ignored.txt").to_s,
         @source_path.join("nested/test2.txt").to_s,
-        @source_path.join("nested/_nested_ignored.txt").to_s
+        @source_path.join("nested/_nested_ignored.txt").to_s,
+        @source_path.join("linked/linked_file.txt").to_s,
+        @source_path.join("linked_file2.txt").to_s,
       ].sort
       assert_that(subject.files).equals(exp_files)
     end
@@ -39,6 +41,8 @@ class Dassets::Source
       exp_files = [
         @source_path.join("test1.txt").to_s,
         @source_path.join("nested/test2.txt").to_s,
+        @source_path.join("linked/linked_file.txt").to_s,
+        @source_path.join("linked_file2.txt").to_s,
       ].sort
 
       assert_that(subject.files).equals(exp_files)


### PR DESCRIPTION
This allows symlinked source files to be detected by Dassets.

# Other Changes

### update more single-quote strings to double-quote

This is a style convention thing. There was still a bunch of old
code using single quote strings so this updates them to match our
latest convention.

### add frozen string literal magic comments to lib files

This is part of our new conventions going forward. Not only are
immutable Strings better in general, they may become default in
future-Ruby.