### PR TITLE
allow registering multiple engines per extension

### DIFF
--- a/lib/dassets/config.rb
+++ b/lib/dassets/config.rb
@@ -21,6 +21,7 @@ class Dassets::Config
   def reset
     @sources      = []
     @combinations = Hash.new { |h, k| [k] } # digest pass-thru if none defined
+    @file_store   = Dassets::NullFileStore.new
   end
 
   def base_url(value = nil)

--- a/lib/dassets/engine.rb
+++ b/lib/dassets/engine.rb
@@ -17,13 +17,3 @@ class Dassets::Engine
     raise NotImplementedError
   end
 end
-
-class Dassets::NullEngine < Dassets::Engine
-  def ext(input_ext)
-    input_ext
-  end
-
-  def compile(input)
-    input
-  end
-end

--- a/lib/dassets/source.rb
+++ b/lib/dassets/source.rb
@@ -9,7 +9,7 @@ class Dassets::Source
   def initialize(path)
     @path             = path.to_s
     @filter           = proc{ |paths| paths }
-    @engines          = Hash.new{ |h,k| Dassets::NullEngine.new }
+    @engines          = Hash.new{ |hash, key| hash[key] = [] }
     @response_headers = Hash.new
   end
 
@@ -20,7 +20,7 @@ class Dassets::Source
   def engine(input_ext, engine_class, registered_opts = nil)
     default_opts = { "source_path" => @path }
     engine_opts = default_opts.merge(registered_opts || {})
-    @engines[input_ext.to_s] = engine_class.new(engine_opts)
+    @engines[input_ext.to_s] << engine_class.new(engine_opts)
   end
 
   def files

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -38,7 +38,10 @@ class Dassets::SourceFile
         digest_basename =
           @ext_list
             .reduce([]) { |digest_ext_list, ext|
-              digest_ext_list << self.source.engines[ext].ext(ext)
+              digest_ext_list <<
+                self.source.engines[ext].reduce(ext) { |ext_acc, engine|
+                  engine.ext(ext_acc)
+                }
             }
             .reject(&:empty?)
             .reverse
@@ -49,8 +52,10 @@ class Dassets::SourceFile
   end
 
   def compiled
-    @ext_list.reduce(read_file(@file_path)) { |content, ext|
-      self.source.engines[ext].compile(content)
+    @ext_list.reduce(read_file(@file_path)) { |file_acc, ext|
+      self.source.engines[ext].reduce(file_acc) { |ext_acc, engine|
+        engine.compile(ext_acc)
+      }
     }
   end
 

--- a/test/unit/engine_tests.rb
+++ b/test/unit/engine_tests.rb
@@ -21,26 +21,3 @@ class Dassets::Engine
     end
   end
 end
-
-class Dassets::NullEngine
-  class UnitTests < Assert::Context
-    desc "Dassets::NullEngine"
-    subject { Dassets::NullEngine.new("some" => "opts") }
-
-    should "be a Engine" do
-      assert_that(subject).is_kind_of(Dassets::Engine)
-    end
-
-    should "know its opts" do
-      assert_that(subject.opts).equals({ "some" => "opts" })
-    end
-
-    should "return the given extension on `ext`" do
-      assert_that(subject.ext("foo")).equals("foo")
-    end
-
-    should "return the given input on `compile" do
-      assert_that(subject.compile("some content")).equals("some content")
-    end
-  end
-end

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -48,9 +48,10 @@ class Dassets::Source
       assert_that(subject.files).equals(exp_files)
     end
 
-    should "know its engines and return a NullEngine by default" do
+    should "know its extension-specific engines and return an empty Array by "\
+           "default" do
       assert_that(subject.engines).is_kind_of(::Hash)
-      assert_that(subject.engines["something"]).is_kind_of(Dassets::NullEngine)
+      assert_that(subject.engines["something"]).equals([])
     end
 
     should "know its response headers" do
@@ -103,30 +104,33 @@ class Dassets::Source
     end
 
     should "allow registering new engines" do
-      assert_that(subject.engines["empty"]).is_kind_of(Dassets::NullEngine)
+      assert_that(subject.engines["empty"]).equals([])
 
       subject.engine "empty", @empty_engine, "an" => "opt"
-      assert_that(subject.engines["empty"]).is_kind_of(@empty_engine)
-      assert_that(subject.engines["empty"].opts["an"]).equals("opt")
-      assert_that(subject.engines["empty"].ext("empty")).equals("")
-      assert_that(subject.engines["empty"].compile("some content")).equals("")
+      assert_that(subject.engines["empty"]).is_kind_of(Array)
+      assert_that(subject.engines["empty"].size).equals(1)
+      assert_that(subject.engines["empty"].first.opts["an"]).equals("opt")
+      assert_that(subject.engines["empty"].first.ext("empty")).equals("")
+      assert_that(subject.engines["empty"].first.compile("some content")).equals("")
     end
 
     should "register with the source path as a default option" do
       subject.engine "empty", @empty_engine
       exp_opts = { "source_path" => subject.path }
-      assert_that(subject.engines["empty"].opts).equals(exp_opts)
+      assert_that(subject.engines["empty"].first.opts).equals(exp_opts)
 
+      subject.engines["empty"] = []
       subject.engine "empty", @empty_engine, "an" => "opt"
       exp_opts = {
         "source_path" => subject.path,
         "an" => "opt"
       }
-      assert_that(subject.engines["empty"].opts).equals(exp_opts)
+      assert_that(subject.engines["empty"].first.opts).equals(exp_opts)
 
+      subject.engines["empty"] = []
       subject.engine "empty", @empty_engine, "source_path" => "something"
       exp_opts = { "source_path" => "something" }
-      assert_that(subject.engines["empty"].opts).equals(exp_opts)
+      assert_that(subject.engines["empty"].first.opts).equals(exp_opts)
     end
   end
 end


### PR DESCRIPTION
This allows you to e.g. compile using dassets-erb's ERB engine
implicitly on all .scss files while also e.g. compiling using
dassets-sass's SCSS engine on all .scss. files too. Engines
will be executed on files in the order they are configured on
the sources.

Example configuration:

```ruby
requirb "dassets"
require "dassets-erb"
require "dassets-sass"

Dassets.configure do |c|
  c.source "/path/to/assets") do |s|
    # Have all .scss files first compile using Dassets::Erb to resolve any
    # ERB expressions, then compile using Dassets::Sass.
    s.engine "scss", Dassets::Erb::Engine
    s.engine "scss", Dassets::Sass::Engine, syntax: Dassets::Sass::SCSS
  end
end
```

# Other Changes

### reset the file store when resetting

This was missed in earlier implementations and testing. I noticed
this while testing Dassets with MuchRails.