### PR TITLE
allow configuring Source base paths

### DIFF
--- a/lib/dassets/source.rb
+++ b/lib/dassets/source.rb
@@ -14,6 +14,15 @@ class Dassets::Source
     @response_headers = {}
   end
 
+  def base_path(value = nil)
+    set_base_path(value) unless value.nil?
+    @base_path
+  end
+
+  def set_base_path(value)
+    @base_path = value
+  end
+
   def filter(&block)
     block.nil? ? @filter : @filter = block
   end

--- a/lib/dassets/source_file.rb
+++ b/lib/dassets/source_file.rb
@@ -49,7 +49,11 @@ class Dassets::SourceFile
             .join(".")
 
         File.join(
-          [digest_dirname(@file_path), digest_basename].reject(&:empty?),
+          [
+            base_path,
+            digest_dirname(@file_path),
+            digest_basename,
+          ].reject(&:empty?),
         )
       end
   end
@@ -68,6 +72,10 @@ class Dassets::SourceFile
 
   def mtime
     File.mtime(@file_path)
+  end
+
+  def base_path
+    source&.base_path.to_s
   end
 
   def response_headers

--- a/test/unit/source_file_tests.rb
+++ b/test/unit/source_file_tests.rb
@@ -18,7 +18,8 @@ class Dassets::SourceFile
 
     should have_readers :file_path
     should have_imeths :source, :asset_file, :digest_path
-    should have_imeths :compiled, :exists?, :mtime, :response_headers
+    should have_imeths :compiled, :exists?, :mtime
+    should have_imeths :base_path, :response_headers
     should have_cmeth :find_by_digest_path
 
     should "know its file path" do
@@ -57,6 +58,10 @@ class Dassets::SourceFile
 
     should "use the response headers of its source as its response headers" do
       assert_that(subject.response_headers).is(subject.source.response_headers)
+    end
+
+    should "use the base path of its source as its base path" do
+      assert_that(subject.base_path).equals(subject.source.base_path.to_s)
     end
 
     should "be findable by its digest path" do

--- a/test/unit/source_tests.rb
+++ b/test/unit/source_tests.rb
@@ -15,6 +15,7 @@ class Dassets::Source
     end
 
     should have_reader :path, :engines, :response_headers
+    should have_imeths :base_path, :set_base_path
     should have_imeth :files, :filter, :engine
 
     should "know its path and default filter" do
@@ -22,6 +23,28 @@ class Dassets::Source
       assert_that(subject.filter).is_kind_of(Proc)
       assert_that(subject.filter.call(["file1", "file2"]))
         .equals(["file1", "file2"])
+    end
+
+    should "have no base path by default" do
+      assert_that(subject.base_path).is_nil
+    end
+
+    should "set non-nil base paths" do
+      path = Factory.path
+      subject.base_path path
+      assert_that(subject.base_path).equals(path)
+
+      subject.base_path(nil)
+      assert_that(subject.base_path).equals(path)
+    end
+
+    should "force set any base paths" do
+      path = Factory.path
+      subject.set_base_path path
+      assert_that(subject.base_path).equals(path)
+
+      subject.set_base_path(nil)
+      assert_that(subject.base_path).is_nil
     end
 
     should "know its files" do


### PR DESCRIPTION
This allows you to configure individual subdirectories of a
directory tree as sources but host/serve files out of a common
root path/url. This is usefule if not all directories in the
root tree share the same configuration needs.
