### PR TITLE
switch to writing file store assets using "wb"

### DIFF
--- a/lib/dassets/file_store.rb
+++ b/lib/dassets/file_store.rb
@@ -16,7 +16,7 @@ class Dassets::FileStore
     @save_mutex.synchronize do
       store_path(url_path).tap do |path|
         FileUtils.mkdir_p(File.dirname(path))
-        File.open(path, "w"){ |f| f.write(block.call) }
+        File.open(path, "wb"){ |f| f.write(block.call) }
       end
     end
   end


### PR DESCRIPTION
This ensures you write binary files, e.g images, and don't run into
any weird text encoding issues.
